### PR TITLE
ci: fix release workflow input var names

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -31,5 +31,5 @@ jobs:
         if: '!github.event.push.repository.fork'
         secrets: inherit
         with:
-            publish-apphub: true
-            publish-github: true
+            publish_apphub: true
+            publish_github: true


### PR DESCRIPTION
Got the wrong input format for the [release workflow](https://github.com/dhis2/workflows-platform/blob/v1/.github/workflows/release.yml) -- looks like underscores are right at this step