### PR TITLE
fix: round CHRIPS values to two decimals

### DIFF
--- a/src/data/datasets.js
+++ b/src/data/datasets.js
@@ -3,6 +3,7 @@ import {
     kelvinToCelsius,
     getRelativeHumidity,
     roundOneDecimal,
+    roundTwoDecimal,
 } from '../utils/calc.js'
 import { HOURLY, MONTHLY } from '../utils/time.js'
 
@@ -123,6 +124,7 @@ export default [
         resolution: chirpsResolution,
         band: 'precipitation',
         reducer: 'mean',
+        valueParser: roundTwoDecimal,
         aggregationType: i18n.t('Sum'),
         dataElementCode: 'CHIRPS_PRECIPITATION',
     },

--- a/src/data/datasets.js
+++ b/src/data/datasets.js
@@ -3,7 +3,7 @@ import {
     kelvinToCelsius,
     getRelativeHumidity,
     roundOneDecimal,
-    roundTwoDecimal,
+    roundTwoDecimals,
 } from '../utils/calc.js'
 import { HOURLY, MONTHLY } from '../utils/time.js'
 
@@ -124,7 +124,7 @@ export default [
         resolution: chirpsResolution,
         band: 'precipitation',
         reducer: 'mean',
-        valueParser: roundTwoDecimal,
+        valueParser: roundTwoDecimals,
         aggregationType: i18n.t('Sum'),
         dataElementCode: 'CHIRPS_PRECIPITATION',
     },

--- a/src/utils/calc.js
+++ b/src/utils/calc.js
@@ -5,7 +5,7 @@ export const getRelativeHumidity = (temperature, dewpoint) =>
 
 export const roundOneDecimal = (v) => Math.round(v * 10) / 10
 
-export const roundTwoDecimal = (v) => Math.round(v * 100) / 100
+export const roundTwoDecimals = (v) => Math.round(v * 100) / 100
 
 export const kelvinToCelsius = (k) => k - 273.15
 

--- a/src/utils/calc.js
+++ b/src/utils/calc.js
@@ -5,6 +5,8 @@ export const getRelativeHumidity = (temperature, dewpoint) =>
 
 export const roundOneDecimal = (v) => Math.round(v * 10) / 10
 
+export const roundTwoDecimal = (v) => Math.round(v * 100) / 100
+
 export const kelvinToCelsius = (k) => k - 273.15
 
 export const toCelcius = (k) => roundOneDecimal(kelvinToCelsius(k))


### PR DESCRIPTION
Round CHIRPS precipitations values using two decimals before importing to DHIS2. 

After this PR values will be rounded:

![Screenshot 2025-01-28 at 12 10 31](https://github.com/user-attachments/assets/0c1ed547-37f3-46ef-a338-3ff69ad27c4c)
