### PR TITLE
fix: climate normals

### DIFF
--- a/src/components/explore/climateChange/charts/temperatureAnomaly.js
+++ b/src/components/explore/climateChange/charts/temperatureAnomaly.js
@@ -2,7 +2,6 @@ import i18n from '@dhis2/d2-i18n'
 import { colors } from '@dhis2/ui'
 import { roundOneDecimal } from '../../../../utils/calc.js'
 import { animation, credits } from '../../../../utils/chart.js'
-import { padWithZeroes } from '../../../../utils/time.js'
 import { months } from '../../MonthSelect.jsx'
 
 const band = 'temperature_2m'
@@ -15,7 +14,7 @@ const getChartConfig = ({
     referencePeriod,
     settings,
 }) => {
-    const normal = normals.find((n) => n.id === padWithZeroes(month))[band]
+    const normal = normals.find((n) => n.id === month)[band]
     const years = data.map((d) => d.id.substring(0, 4))
     const monthName = months.find((m) => m.id === month).name
     const series = data.map((d) => roundOneDecimal(d[band] - normal))

--- a/src/utils/__tests__/chart.test.js
+++ b/src/utils/__tests__/chart.test.js
@@ -85,8 +85,8 @@ describe('chart utils', () => {
     })
 
     it('it should get month from id', () => {
-        expect(getMonthFromId('2023-12-30')).toEqual('12')
-        expect(getMonthFromId('2024-01-01')).toEqual('01')
+        expect(getMonthFromId('2023-12-30')).toEqual(12)
+        expect(getMonthFromId('2024-01-01')).toEqual(1)
     })
 
     it('it should get daily period', () => {

--- a/src/utils/chart.js
+++ b/src/utils/chart.js
@@ -9,7 +9,7 @@ export const animation = {
 
 // Date fromat YYYY-MM
 export const getYearFromId = (id) => id.substring(0, 4)
-export const getMonthFromId = (id) => id.substring(5, 7)
+export const getMonthFromId = (id) => Number(id.substring(5, 7))
 
 export const getSelectedMonths = (data, { startTime, endTime }) =>
     data.filter((d) => d.id >= startTime && d.id <= endTime)


### PR DESCRIPTION
With this PR we calculate the 30 years climate normals in the browser instead of using Google Earth Engine (GEE).  When using GEE we got the wrong result, which was especially noticeable for districts in Rwanda. 

After this PR the temperature anomali in 2022 for Bo in Sierra Leone is 1.2°C (calculated in browser): 

![Screenshot 2025-02-25 at 16 10 55](https://github.com/user-attachments/assets/54ebb753-722b-4ce3-8003-c16459807ac6)

Before this PR the temperature anomali is 1.3°C (calculated on GEE): 

![Screenshot 2025-02-25 at 16 11 46](https://github.com/user-attachments/assets/4c38f1d1-4487-4ce2-ba6b-400c82293e28)

After this PR for Musanze distrinct in Rwanda:

![Screenshot 2025-02-25 at 17 06 10](https://github.com/user-attachments/assets/e1f5c754-4477-4089-8a9b-342c0c068454)

Before: 

![image](https://github.com/user-attachments/assets/982f231d-96ff-4818-9991-872c18adf2c0)

