### PR TITLE
Fix: remove incorrect °C from NDVI tooltip

### DIFF
--- a/src/components/explore/vegetation/charts/vegetation.js
+++ b/src/components/explore/vegetation/charts/vegetation.js
@@ -98,7 +98,7 @@ const getChartConfig = ({
         tooltip: {
             crosshairs: true,
             shared: true,
-            valueSuffix: '°C',
+            valueSuffix: '',
         },
         xAxis: {
             type: 'datetime',


### PR DESCRIPTION
NDVI is unitless and should not have a °C suffix.