### PR TITLE
fix: update minimum supported version to 2.40

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -2,7 +2,7 @@ const config = {
     type: 'app',
     title: 'DHIS2 Climate App',
     id: 'effb986c-a3c7-485e-a2f6-5e54ff9df7c3',
-    minDHIS2Version: '2.37',
+    minDHIS2Version: '2.40',
 
     entryPoints: {
         app: './src/App.jsx',


### PR DESCRIPTION
We officially support the Climate app for the most recent 3 versions of DHIS2. Currently that is 2.40.