### PR TITLE
fix: prevent explore page from crashing when clicking on an org unit

### DIFF
--- a/cypress/e2e/datasets.cy.js
+++ b/cypress/e2e/datasets.cy.js
@@ -189,11 +189,11 @@ describe('Datasets', () => {
 
         cy.contains('Explore weather and climate data').should('be.visible')
 
-        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').click({ multiple: true})
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').eq(0).click()
 
-        cy.wait(1000)
+        cy.contains('No geometry found').should('be.visible')
 
-        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').click({ multiple: true })
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').eq(1).click()
 
         cy.get('h1').should('be.visible')
         cy.contains('Temperature').should('be.visible')
@@ -202,6 +202,8 @@ describe('Datasets', () => {
         cy.contains('Temperature range').should('be.visible')
 
         cy.get('.highcharts-series').should('be.visible')
+        cy.contains('Open as Map').should('exist')
     })
+
 
 })

--- a/cypress/e2e/datasets.cy.js
+++ b/cypress/e2e/datasets.cy.js
@@ -183,4 +183,25 @@ describe('Datasets', () => {
 
         cy.contains('ENACTS datasets could not be loaded').should('be.visible')
     })
+
+    it('should open Explore and show temperature graph for an org unit', () => {
+        cy.visit('#/explore')
+
+        cy.contains('Explore weather and climate data').should('be.visible')
+
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').click({ multiple: true})
+
+        cy.wait(1000)
+
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').click({ multiple: true })
+
+        cy.get('h1').should('be.visible')
+        cy.contains('Temperature').should('be.visible')
+        cy.contains('Precipitation').should('be.visible')
+        cy.contains('Mean temperature').should('be.visible')
+        cy.contains('Temperature range').should('be.visible')
+
+        cy.get('.highcharts-series').should('be.visible')
+    })
+
 })

--- a/src/hooks/useAppVersion.js
+++ b/src/hooks/useAppVersion.js
@@ -74,7 +74,7 @@ const useAppVersion = (key, targetVersion) => {
         } finally {
             setBundledLoading(false)
         }
-    }, [baseUrl])
+    }, [baseUrl, serverVersion])
 
     useEffect(() => {
         fetchBundledApps()

--- a/src/hooks/useAppVersion.js
+++ b/src/hooks/useAppVersion.js
@@ -46,7 +46,7 @@ const isVersionEqualOrHigher = (version, target) => {
 }
 
 const useAppVersion = (key, targetVersion) => {
-    const { baseUrl } = useConfig()
+    const { baseUrl, serverVersion } = useConfig()
     const {
         data: installedApps,
         loading: installedLoading,
@@ -66,7 +66,9 @@ const useAppVersion = (key, targetVersion) => {
             }
 
             const json = await response.json()
-            setBundledApps(json)
+            setBundledApps(
+                serverVersion.minor >= 43 ? json.apps : json // Version Toggle: 2.43 introduced new apps-bundle.json structure
+            )
         } catch (e) {
             setBundledError(e)
         } finally {


### PR DESCRIPTION
v43 uses a new structure for apps-bundle.json. Add a version toggle for version 43 to use new apps-bundle.json structure.  