### PR TITLE
fix: prevent explore page from crashing in 2.43 when clicking on an org unit

### DIFF
--- a/cypress/e2e/datasets.cy.js
+++ b/cypress/e2e/datasets.cy.js
@@ -189,11 +189,15 @@ describe('Datasets', () => {
 
         cy.contains('Explore weather and climate data').should('be.visible')
 
-        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').eq(0).click()
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]')
+            .eq(0)
+            .click()
 
         cy.contains('No geometry found').should('be.visible')
 
-        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').eq(1).click()
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]')
+            .eq(1)
+            .click()
 
         cy.get('h1').should('be.visible')
         cy.contains('Temperature').should('be.visible')
@@ -204,6 +208,4 @@ describe('Datasets', () => {
         cy.get('.highcharts-series').should('be.visible')
         cy.contains('Open as Map').should('exist')
     })
-
-
 })

--- a/cypress/e2e/datasets.cy.js
+++ b/cypress/e2e/datasets.cy.js
@@ -183,4 +183,27 @@ describe('Datasets', () => {
 
         cy.contains('ENACTS datasets could not be loaded').should('be.visible')
     })
+
+    it('should open Explore and show temperature graph for an org unit', () => {
+        cy.visit('#/explore')
+
+        cy.contains('Explore weather and climate data').should('be.visible')
+
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').eq(0).click()
+
+        cy.contains('No geometry found').should('be.visible')
+
+        cy.get('[data-test="dhis2-uiwidgets-orgunittree-node-label"]').eq(1).click()
+
+        cy.get('h1').should('be.visible')
+        cy.contains('Temperature').should('be.visible')
+        cy.contains('Precipitation').should('be.visible')
+        cy.contains('Mean temperature').should('be.visible')
+        cy.contains('Temperature range').should('be.visible')
+
+        cy.get('.highcharts-series').should('be.visible')
+        cy.contains('Open as Map').should('exist')
+    })
+
+
 })

--- a/src/hooks/useAppVersion.js
+++ b/src/hooks/useAppVersion.js
@@ -46,7 +46,7 @@ const isVersionEqualOrHigher = (version, target) => {
 }
 
 const useAppVersion = (key, targetVersion) => {
-    const { baseUrl } = useConfig()
+    const { baseUrl, serverVersion } = useConfig()
     const {
         data: installedApps,
         loading: installedLoading,
@@ -66,13 +66,15 @@ const useAppVersion = (key, targetVersion) => {
             }
 
             const json = await response.json()
-            setBundledApps(json)
+            setBundledApps(
+                serverVersion.minor >= 43 ? json.apps : json // Version Toggle: 2.43 introduced new apps-bundle.json structure
+            )
         } catch (e) {
             setBundledError(e)
         } finally {
             setBundledLoading(false)
         }
-    }, [baseUrl])
+    }, [baseUrl, serverVersion])
 
     useEffect(() => {
         fetchBundledApps()

--- a/yarn.lock
+++ b/yarn.lock
@@ -10484,11 +10484,6 @@ regenerate@^1.4.2:
   resolved "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz"
   integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
-regenerator-runtime@^0.14.0:
-  version "0.14.1"
-  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz"
-  integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
-
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"


### PR DESCRIPTION
v43 uses a new structure for apps-bundle.json. Add a version toggle for version 43 to use
new apps-bundle.json structure.

Authored by Katherine Wyers

CLIM-686