### PR TITLE
fix: prevent crash when clicking on data source link in Explore pages

### DIFF
--- a/src/components/explore/Chart.jsx
+++ b/src/components/explore/Chart.jsx
@@ -24,18 +24,18 @@ const Chart = ({ config }) => {
 
     useLayoutEffect(() => {
         Highcharts.chart(chartRef.current, mergedConfig)
-    }, [mergedConfig, chartRef])
+    }, [config, chartRef])
 
     return (
         <>
             <div ref={chartRef} />
-            <a href={mergedConfig.credits.href} target='_blank' rel='noopener noreferrer' style={{ fontSize: '10px', color: 'grey', display: 'block', textAlign: 'right', textDecoration: 'none' }}>{mergedConfig.credits.text}</a>
+            <a href={mergedConfig.credits?.href} target='_blank' rel='noopener noreferrer' style={{ fontSize: '10px', color: 'grey', display: 'block', textAlign: 'right', textDecoration: 'none' }}>{mergedConfig.credits?.text}</a>
         </>
     )
 }
 
 Chart.propTypes = {
-    mergedConfig: PropTypes.object.isRequired,
+    config: PropTypes.object.isRequired,
 }
 
 export default Chart

--- a/src/components/explore/Chart.jsx
+++ b/src/components/explore/Chart.jsx
@@ -48,7 +48,12 @@ const Chart = ({ config }) => {
 }
 
 Chart.propTypes = {
-    config: PropTypes.object.isRequired,
+    config: PropTypes.shape({
+        credits: PropTypes.shape({
+            href: PropTypes.string,
+            text: PropTypes.string,
+        }),
+    }).isRequired,
 }
 
 export default Chart

--- a/src/components/explore/Chart.jsx
+++ b/src/components/explore/Chart.jsx
@@ -14,15 +14,29 @@ patternFill(Highcharts)
 const Chart = ({ config }) => {
     const chartRef = useRef()
 
-    useLayoutEffect(() => {
-        Highcharts.chart(chartRef.current, config)
-    }, [config, chartRef])
+    const mergedConfig = {
+        ...config,
+        credits: { 
+            ...config.credits,
+            enabled: false 
+        },
+    }
 
-    return <div ref={chartRef} />
+    useLayoutEffect(() => {
+        Highcharts.chart(chartRef.current, mergedConfig)
+    }, [mergedConfig, chartRef])
+
+    return (
+        <>
+            <div ref={chartRef} />
+            <a href={mergedConfig.credits.href} target='_blank' rel='noopener noreferrer' style={{ fontSize: '10px', color: 'grey', display: 'block', textAlign: 'right', textDecoration: 'none' }}>{mergedConfig.credits.text}</a>
+        </>
+    )
 }
 
 Chart.propTypes = {
-    config: PropTypes.object.isRequired,
+    mergedConfig: PropTypes.object.isRequired,
 }
 
 export default Chart
+

--- a/src/components/explore/Chart.jsx
+++ b/src/components/explore/Chart.jsx
@@ -24,7 +24,7 @@ const Chart = ({ config }) => {
 
     useLayoutEffect(() => {
         Highcharts.chart(chartRef.current, mergedConfig)
-    }, [config, chartRef])
+    }, [mergedConfig, chartRef])
 
     return (
         <>

--- a/src/components/explore/Chart.jsx
+++ b/src/components/explore/Chart.jsx
@@ -14,22 +14,35 @@ patternFill(Highcharts)
 const Chart = ({ config }) => {
     const chartRef = useRef()
 
-    const mergedConfig = {
-        ...config,
-        credits: { 
-            ...config.credits,
-            enabled: false 
-        },
-    }
-
     useLayoutEffect(() => {
+        const mergedConfig = {
+            ...config,
+            credits: {
+                ...config.credits,
+                enabled: false,
+            },
+        }
+
         Highcharts.chart(chartRef.current, mergedConfig)
-    }, [mergedConfig, chartRef])
+    }, [config])
 
     return (
         <>
             <div ref={chartRef} />
-            <a href={mergedConfig.credits?.href} target='_blank' rel='noopener noreferrer' style={{ fontSize: '10px', color: 'grey', display: 'block', textAlign: 'right', textDecoration: 'none' }}>{mergedConfig.credits?.text}</a>
+            <a
+                href={config.credits?.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                    fontSize: '10px',
+                    color: 'grey',
+                    display: 'block',
+                    textAlign: 'right',
+                    textDecoration: 'none',
+                }}
+            >
+                {config.credits?.text}
+            </a>
         </>
     )
 }
@@ -39,4 +52,3 @@ Chart.propTypes = {
 }
 
 export default Chart
-

--- a/src/utils/chart.js
+++ b/src/utils/chart.js
@@ -38,30 +38,30 @@ export const strokePattern = {
 }
 
 export const credits = {
-    href: 'https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land',
+    href: 'javascript:window.open("https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land", "_blank")',
     text: i18n.t(
         'ERA5-Land / Copernicus Climate Change Service / Google Earth Engine'
     ),
 }
 
 export const heatCredits = {
-    href: 'https://cds.climate.copernicus.eu/cdsapp#!/dataset/derived-utci-historical',
+    href: 'javascript:window.open("https://cds.climate.copernicus.eu/cdsapp#!/dataset/derived-utci-historical", "_blank")',
     text: i18n.t(
         'ERA5-HEAT / Copernicus Climate Change Service / Google Earth Engine'
     ),
 }
 
 export const vegetationCredits = {
-    href: 'https://lpdaac.usgs.gov/products/mod13q1v061/',
+    href: 'javascript:window.open("https://lpdaac.usgs.gov/products/mod13q1v061/", "_blank")',
     text: i18n.t('NASA LP DAAC at the USGS EROS Center / Google Earth Engine'),
 }
 
 export const landCoverCredits = {
-    href: 'https://lpdaac.usgs.gov/products/mcd12q1v061/',
+    href: 'javascript:window.open("https://lpdaac.usgs.gov/products/mcd12q1v061/", "_blank")',
     text: i18n.t('NASA LP DAAC at the USGS EROS Center / Google Earth Engine'),
 }
 
 export const elevationCredits = {
-    href: 'https://lpdaac.usgs.gov/products/srtmgl1v003/',
+    href: 'javascript:window.open("https://lpdaac.usgs.gov/products/srtmgl1v003/", "_blank")',
     text: i18n.t('NASA / USGS / JPL-Caltech / Google Earth Engine'),
 }

--- a/src/utils/chart.js
+++ b/src/utils/chart.js
@@ -38,30 +38,30 @@ export const strokePattern = {
 }
 
 export const credits = {
-    href: 'javascript:window.open("https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land", "_blank")',
+    href: 'https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land',
     text: i18n.t(
         'ERA5-Land / Copernicus Climate Change Service / Google Earth Engine'
     ),
 }
 
 export const heatCredits = {
-    href: 'javascript:window.open("https://cds.climate.copernicus.eu/cdsapp#!/dataset/derived-utci-historical", "_blank")',
+    href: 'https://cds.climate.copernicus.eu/cdsapp#!/dataset/derived-utci-historical',
     text: i18n.t(
         'ERA5-HEAT / Copernicus Climate Change Service / Google Earth Engine'
     ),
 }
 
 export const vegetationCredits = {
-    href: 'javascript:window.open("https://lpdaac.usgs.gov/products/mod13q1v061/", "_blank")',
+    href: 'https://lpdaac.usgs.gov/products/mod13q1v061/',
     text: i18n.t('NASA LP DAAC at the USGS EROS Center / Google Earth Engine'),
 }
 
 export const landCoverCredits = {
-    href: 'javascript:window.open("https://lpdaac.usgs.gov/products/mcd12q1v061/", "_blank")',
+    href: 'https://lpdaac.usgs.gov/products/mcd12q1v061/',
     text: i18n.t('NASA LP DAAC at the USGS EROS Center / Google Earth Engine'),
 }
 
 export const elevationCredits = {
-    href: 'javascript:window.open("https://lpdaac.usgs.gov/products/srtmgl1v003/", "_blank")',
+    href: 'https://lpdaac.usgs.gov/products/srtmgl1v003/',
     text: i18n.t('NASA / USGS / JPL-Caltech / Google Earth Engine'),
 }


### PR DESCRIPTION
Hide the credits in the HighChart in /explore and replace it with a html caption that opens in a new tab with target='_blank'. This stops the app from crashing when clicking the credits link in /explore charts without opening up new vulnerabilities

CLIM-94

https://dhis2.atlassian.net/browse/CLIM-94