### PR TITLE
feat: add fixed period selectors to climate imports

### DIFF
--- a/cypress/e2e/import.cy.js
+++ b/cypress/e2e/import.cy.js
@@ -66,7 +66,41 @@ const selectTargetDataElement = (dataElementName) => {
         .click()
 }
 
-const typeStartAndEndDates = (startDate, endDate) => {
+const parseDate = (dateString) => {
+    const [year, month, day] = dateString.split('-').map(Number)
+    return new Date(Date.UTC(year, month - 1, day))
+}
+
+const getWeeklyPeriodId = (dateString) => {
+    const date = parseDate(dateString)
+    const day = date.getUTCDay() || 7
+    date.setUTCDate(date.getUTCDate() + 4 - day)
+
+    const isoYear = date.getUTCFullYear()
+    const yearStart = new Date(Date.UTC(isoYear, 0, 1))
+    const week = Math.ceil(((date - yearStart) / 86400000 + 1) / 7)
+
+    return `${isoYear}W${week}`
+}
+
+const getMonthlyPeriodId = (dateString) =>
+    dateString.replaceAll('-', '').slice(0, 6)
+
+const getPeriodIdForDate = (dateString, periodType) =>
+    periodType === 'monthly'
+        ? getMonthlyPeriodId(dateString)
+        : getWeeklyPeriodId(dateString)
+
+const selectFixedPeriod = (fieldDataTest, periodId) => {
+    cy.getByDataTest(fieldDataTest).scrollIntoView()
+    cy.getByDataTest(fieldDataTest).click()
+    cy.getByDataTest(`${fieldDataTest}-visible-year`).select(
+        periodId.slice(0, 4)
+    )
+    cy.getByDataTest(`${fieldDataTest}-option-${periodId}`).click()
+}
+
+const typeCalendarStartAndEndDates = (startDate, endDate) => {
     // Type the start date directly into the input, ignoring the calendar popup
     cy.getByDataTest('start-date-input-content').scrollIntoView()
     cy.getByDataTest('start-date-input-content').find('input').clear()
@@ -76,6 +110,69 @@ const typeStartAndEndDates = (startDate, endDate) => {
     cy.getByDataTest('end-date-input-content').find('input').clear()
     cy.getByDataTest('end-date-input-content').find('input').type(endDate)
     cy.getByDataTest('end-date-input-content').find('input').blur()
+}
+
+const typeStartAndEndDates = (startDate, endDate, periodType = 'weekly') => {
+    cy.get(
+        '[data-test="start-period-input"], [data-test="start-date-input-content"]'
+    )
+        .first()
+        .then(($field) => {
+            if ($field.attr('data-test') === 'start-period-input') {
+                selectFixedPeriod(
+                    'start-period-input',
+                    getPeriodIdForDate(startDate, periodType)
+                )
+                selectFixedPeriod(
+                    'end-period-input',
+                    getPeriodIdForDate(endDate, periodType)
+                )
+                return
+            }
+
+            typeCalendarStartAndEndDates(startDate, endDate)
+        })
+}
+
+const assertFixedPeriodSelection = (fieldDataTest, periodId) => {
+    cy.getByDataTest(fieldDataTest).scrollIntoView()
+    cy.getByDataTest(fieldDataTest).click()
+    cy.getByDataTest(`${fieldDataTest}-visible-year`).select(
+        periodId.slice(0, 4)
+    )
+    cy.getByDataTest(`${fieldDataTest}-option-${periodId}`)
+        .should('have.attr', 'aria-pressed', 'true')
+        .click()
+}
+
+const assertDateRangeSelection = (
+    startDate,
+    endDate,
+    periodType = 'weekly'
+) => {
+    cy.get('[data-test="start-period-input"], [data-test="start-date-input"]')
+        .first()
+        .then(($field) => {
+            if ($field.attr('data-test') === 'start-period-input') {
+                assertFixedPeriodSelection(
+                    'start-period-input',
+                    getPeriodIdForDate(startDate, periodType)
+                )
+                assertFixedPeriodSelection(
+                    'end-period-input',
+                    getPeriodIdForDate(endDate, periodType)
+                )
+                return
+            }
+
+            cy.getByDataTest('start-date-input').scrollIntoView()
+            cy.getByDataTest('start-date-input')
+                .find('input')
+                .should('have.value', startDate)
+            cy.getByDataTest('end-date-input')
+                .find('input')
+                .should('have.value', endDate)
+        })
 }
 
 const verifyImportPreview = ({
@@ -267,13 +364,7 @@ describe('Import', () => {
             dataValues: 39,
         })
 
-        cy.getByDataTest('start-date-input').scrollIntoView()
-        cy.getByDataTest('start-date-input')
-            .find('input')
-            .should('have.value', nonBoundaryStartDate)
-        cy.getByDataTest('end-date-input')
-            .find('input')
-            .should('have.value', nonBoundaryEndDate)
+        assertDateRangeSelection(nonBoundaryStartDate, nonBoundaryEndDate)
     })
 
     it('allows user to select time zone if not in Etc/UTC', () => {
@@ -339,13 +430,7 @@ describe('Import', () => {
             dataValues: 39,
         })
 
-        cy.getByDataTest('start-date-input').scrollIntoView()
-        cy.getByDataTest('start-date-input')
-            .find('input')
-            .should('have.value', nonBoundaryStartDate)
-        cy.getByDataTest('end-date-input')
-            .find('input')
-            .should('have.value', nonBoundaryEndDate)
+        assertDateRangeSelection(nonBoundaryStartDate, nonBoundaryEndDate)
     })
 
     it('select the correct org unit groups and import the correct values', () => {
@@ -608,7 +693,7 @@ describe('Import', () => {
         selectOrgUnitFromTree('Bonthe')
         removeOrgUnitLevel('District')
 
-        typeStartAndEndDates('2025-12-24', '2026-01-16')
+        typeStartAndEndDates('2025-12-24', '2026-01-16', 'monthly')
 
         verifyImportPreview({
             datasetName: 'Precipitation (ERA5-Land)',

--- a/cypress/e2e/save-import.cy.js
+++ b/cypress/e2e/save-import.cy.js
@@ -69,13 +69,110 @@ const selectTargetDataElement = (dataElementName) => {
         .click()
 }
 
-const typeStartAndEndDates = (startDate, endDate) => {
+const parseDate = (dateString) => {
+    const [year, month, day] = dateString.split('-').map(Number)
+    return new Date(Date.UTC(year, month - 1, day))
+}
+
+const formatDate = (date) => date.toISOString().slice(0, 10)
+
+const getWeeklyPeriodId = (dateString) => {
+    const date = parseDate(dateString)
+    const day = date.getUTCDay() || 7
+    date.setUTCDate(date.getUTCDate() + 4 - day)
+
+    const isoYear = date.getUTCFullYear()
+    const yearStart = new Date(Date.UTC(isoYear, 0, 1))
+    const week = Math.ceil(((date - yearStart) / 86400000 + 1) / 7)
+
+    return `${isoYear}W${week}`
+}
+
+const getWeeklyPeriodEndDate = (dateString) => {
+    const date = parseDate(dateString)
+    const day = date.getUTCDay() || 7
+    date.setUTCDate(date.getUTCDate() + 7 - day)
+    return formatDate(date)
+}
+
+const getMonthlyPeriodId = (dateString) =>
+    dateString.replaceAll('-', '').slice(0, 6)
+
+const getMonthlyPeriodEndDate = (dateString) => {
+    const [year, month] = dateString.split('-').map(Number)
+    return formatDate(new Date(Date.UTC(year, month, 0)))
+}
+
+const getPeriodIdForDate = (dateString, periodType) =>
+    periodType === 'monthly'
+        ? getMonthlyPeriodId(dateString)
+        : getWeeklyPeriodId(dateString)
+
+const getPeriodEndDate = (dateString, periodType = 'weekly') =>
+    periodType === 'monthly'
+        ? getMonthlyPeriodEndDate(dateString)
+        : getWeeklyPeriodEndDate(dateString)
+
+const selectFixedPeriod = (fieldDataTest, periodId) => {
+    cy.getByDataTest(fieldDataTest).scrollIntoView()
+    cy.getByDataTest(fieldDataTest).click()
+    cy.getByDataTest(`${fieldDataTest}-visible-year`).select(
+        periodId.slice(0, 4)
+    )
+    cy.getByDataTest(`${fieldDataTest}-option-${periodId}`).click()
+}
+
+const typeCalendarStartAndEndDates = (startDate, endDate) => {
     cy.getByDataTest('start-date-input-content').scrollIntoView()
     cy.getByDataTest('start-date-input-content').find('input').clear()
     cy.getByDataTest('start-date-input-content').find('input').type(startDate)
     cy.getByDataTest('end-date-input-content').find('input').clear()
     cy.getByDataTest('end-date-input-content').find('input').type(endDate)
     cy.getByDataTest('end-date-input-content').find('input').blur()
+}
+
+const typeStartAndEndDates = (startDate, endDate, periodType = 'weekly') => {
+    cy.get(
+        '[data-test="start-period-input"], [data-test="start-date-input-content"]'
+    )
+        .first()
+        .then(($field) => {
+            if ($field.attr('data-test') === 'start-period-input') {
+                selectFixedPeriod(
+                    'start-period-input',
+                    getPeriodIdForDate(startDate, periodType)
+                )
+                selectFixedPeriod(
+                    'end-period-input',
+                    getPeriodIdForDate(endDate, periodType)
+                )
+                return
+            }
+
+            typeCalendarStartAndEndDates(startDate, endDate)
+        })
+}
+
+const typeEndDate = (endDate, periodType = 'weekly') => {
+    cy.get(
+        '[data-test="end-period-input"], [data-test="end-date-input-content"]'
+    )
+        .first()
+        .then(($field) => {
+            if ($field.attr('data-test') === 'end-period-input') {
+                selectFixedPeriod(
+                    'end-period-input',
+                    getPeriodIdForDate(endDate, periodType)
+                )
+                return
+            }
+
+            cy.getByDataTest('end-date-input-content').find('input').clear()
+            cy.getByDataTest('end-date-input-content')
+                .find('input')
+                .type(endDate)
+            cy.getByDataTest('end-date-input-content').find('input').blur()
+        })
 }
 
 const fillImportForm = () => {
@@ -311,6 +408,9 @@ describe('Imports overview', () => {
     })
 
     it('updates the last import date on the card after running with changed dates', () => {
+        const changedEndDate = '2026-05-07'
+        const changedEndPeriodEndDate = getPeriodEndDate(changedEndDate)
+
         cy.intercept('GET', DATASTORE_URL, { configs: [MOCK_CONFIG] }).as(
             'getDataStore'
         )
@@ -328,8 +428,7 @@ describe('Imports overview', () => {
 
         cy.contains('button', 'Change').click()
 
-        cy.getByDataTest('end-date-input').find('input').clear()
-        cy.getByDataTest('end-date-input').find('input').type('2026-05-07')
+        typeEndDate(changedEndDate)
 
         cy.contains('button', 'Done').click()
 
@@ -343,11 +442,11 @@ describe('Imports overview', () => {
 
         cy.wait('@putDataStore').then((interception) => {
             const config = interception.request.body.configs[0]
-            expect(config.dataUpdatedThrough).to.eq('2026-05-07')
+            expect(config.dataUpdatedThrough).to.eq(changedEndPeriodEndDate)
         })
 
         cy.contains('Data imported through').should('be.visible')
-        cy.contains('May 7, 2026').should('be.visible')
+        cy.contains('May 10, 2026').should('be.visible')
     })
 
     it('deletes a saved import', () => {

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -658,6 +658,15 @@ msgstr "Start date must be on or before the end date."
 msgid "Valid range: {{startDate}} – {{endDate}}"
 msgstr "Valid range: {{startDate}} – {{endDate}}"
 
+msgid "Start period"
+msgstr "Start period"
+
+msgid "End period"
+msgstr "End period"
+
+msgid "No complete periods are available within the valid range."
+msgstr "No complete periods are available within the valid range."
+
 msgid "Valid range"
 msgstr "Valid range"
 
@@ -993,6 +1002,9 @@ msgstr ""
 "None of the selected organisation units have boundaries stored in DHIS2. "
 "Update the import configuration to include organisation units with geometry."
 
+msgid "No complete periods are available within the dataset date range."
+msgstr "No complete periods are available within the dataset date range."
+
 msgid ""
 "Range exceeds the {{max}}-value limit. Split into multiple runs by "
 "importing a shorter date range from the form."
@@ -1008,6 +1020,33 @@ msgstr "Start year"
 
 msgid "End year"
 msgstr "End year"
+
+msgid "Month {{month}}, {{year}}"
+msgstr "Month {{month}}, {{year}}"
+
+msgid "Month {{month}}"
+msgstr "Month {{month}}"
+
+msgid "Select period"
+msgstr "Select period"
+
+msgid "Previous year"
+msgstr "Previous year"
+
+msgid "Select year"
+msgstr "Select year"
+
+msgid "Next year"
+msgstr "Next year"
+
+msgid "Start period must be before or equal to end period."
+msgstr "Start period must be before or equal to end period."
+
+msgid "From period"
+msgstr "From period"
+
+msgid "To period"
+msgstr "To period"
 
 msgid "Chart settings"
 msgstr "Chart settings"

--- a/src/components/import/DateRangePicker.jsx
+++ b/src/components/import/DateRangePicker.jsx
@@ -1,16 +1,30 @@
 import i18n from '@dhis2/d2-i18n'
 import { CalendarInput } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import useUserLocale from '../../hooks/useUserLocale.js'
 import {
+    getCalendarDateBoundaries,
+    getCompleteFixedPeriodRange,
+    getFixedPeriodForDate,
+    getSnappedFixedPeriodRange,
+} from '../../utils/fixedPeriodRange.js'
+import {
+    compareFixedPeriods,
+    normalizeDhis2Calendar,
+} from '../../utils/periodEngine.js'
+import {
+    MONTHLY,
+    WEEKLY,
     YEARLY,
     getDateStringFromIsoDate,
-    normalizeIsoDate,
 } from '../../utils/time.js'
+import { PeriodRangeField } from '../period-picker/index.js'
 import TimeZone from '../shared/TimeZone.jsx'
 import classes from './styles/DateRangePicker.module.css'
 import YearRange from './YearRange.jsx'
+
+const FIXED_RANGE_PERIOD_TYPES = new Set([WEEKLY, MONTHLY])
 
 const getValidationState = (minDate, maxDate, error) => {
     if (!minDate || !maxDate) {
@@ -26,18 +40,72 @@ const DateRangePicker = ({ period, dataset, onChange }) => {
     const [startDateError, setStartDateError] = useState(null)
     const [endDateError, setEndDateError] = useState(null)
 
-    const { startTime, endTime, periodType, calendar } = period
+    const { startTime, endTime, periodType } = period
+    const calendar = normalizeDhis2Calendar(period.calendar)
 
     const matchedPeriodType = dataset?.supportedPeriodTypes?.find(
         (pt) => pt.periodType === periodType
     )
     const periodRange = matchedPeriodType?.periodRange
-    const minCalendarDate = normalizeIsoDate(periodRange?.start) || null
-    const maxCalendarDate = normalizeIsoDate(periodRange?.end) || null
+    const {
+        minStandardDate,
+        maxStandardDate,
+        minCalendarDate,
+        maxCalendarDate,
+    } = useMemo(
+        () => getCalendarDateBoundaries({ periodRange, calendar }),
+        [calendar, periodRange]
+    )
 
     const isYearly = periodType === YEARLY
+    const isFixedRangePeriodType = FIXED_RANGE_PERIOD_TYPES.has(periodType)
     const datasetFromHourlyData = !!(
         dataset?.timeZone || dataset?.bands?.[0]?.timeZone
+    )
+
+    const fixedPeriodRange = useMemo(() => {
+        if (!isFixedRangePeriodType) {
+            return {
+                hasCompleteFixedPeriods: true,
+                maxPeriod: null,
+                maxPeriodId: undefined,
+                minPeriod: null,
+                minPeriodId: undefined,
+            }
+        }
+
+        return getCompleteFixedPeriodRange({
+            periodRange,
+            periodType,
+            calendar,
+            locale,
+        })
+    }, [calendar, isFixedRangePeriodType, locale, periodRange, periodType])
+
+    const selectedStartPeriodId = useMemo(
+        () =>
+            isFixedRangePeriodType
+                ? getFixedPeriodForDate({
+                      date: startTime,
+                      periodType,
+                      calendar,
+                      locale,
+                  })?.id
+                : undefined,
+        [calendar, isFixedRangePeriodType, locale, periodType, startTime]
+    )
+
+    const selectedEndPeriodId = useMemo(
+        () =>
+            isFixedRangePeriodType
+                ? getFixedPeriodForDate({
+                      date: endTime,
+                      periodType,
+                      calendar,
+                      locale,
+                  })?.id
+                : undefined,
+        [calendar, endTime, isFixedRangePeriodType, locale, periodType]
     )
 
     // TimeZone's initialisation effect calls onChange with a functional updater
@@ -58,6 +126,45 @@ const DateRangePicker = ({ period, dataset, onChange }) => {
         [onChange]
     )
 
+    useEffect(() => {
+        if (
+            !isFixedRangePeriodType ||
+            !startTime ||
+            !endTime ||
+            !fixedPeriodRange.hasCompleteFixedPeriods
+        ) {
+            return
+        }
+
+        const snappedRange = getSnappedFixedPeriodRange({
+            startTime,
+            endTime,
+            periodType,
+            calendar,
+            locale,
+            minPeriod: fixedPeriodRange.minPeriod,
+            maxPeriod: fixedPeriodRange.maxPeriod,
+        })
+
+        if (
+            snappedRange &&
+            (snappedRange.startTime !== startTime ||
+                snappedRange.endTime !== endTime)
+        ) {
+            onChange({ ...period, ...snappedRange })
+        }
+    }, [
+        calendar,
+        endTime,
+        fixedPeriodRange,
+        isFixedRangePeriodType,
+        locale,
+        onChange,
+        period,
+        periodType,
+        startTime,
+    ])
+
     const updateStartDate = ({ calendarDateString, validation }) => {
         setStartDateError(validation.valid ? null : validation.validationText)
         onChange({ ...period, startTime: calendarDateString })
@@ -66,6 +173,46 @@ const DateRangePicker = ({ period, dataset, onChange }) => {
     const updateEndDate = ({ calendarDateString, validation }) => {
         setEndDateError(validation.valid ? null : validation.validationText)
         onChange({ ...period, endTime: calendarDateString })
+    }
+
+    const updateStartPeriod = (fixedPeriod) => {
+        const currentEndPeriod = getFixedPeriodForDate({
+            date: endTime,
+            periodType,
+            calendar,
+            locale,
+        })
+        const endTimeUpdate =
+            currentEndPeriod &&
+            compareFixedPeriods(fixedPeriod, currentEndPeriod) <= 0
+                ? endTime
+                : fixedPeriod.endDate
+
+        onChange({
+            ...period,
+            startTime: fixedPeriod.startDate,
+            endTime: endTimeUpdate,
+        })
+    }
+
+    const updateEndPeriod = (fixedPeriod) => {
+        const currentStartPeriod = getFixedPeriodForDate({
+            date: startTime,
+            periodType,
+            calendar,
+            locale,
+        })
+        const startTimeUpdate =
+            currentStartPeriod &&
+            compareFixedPeriods(currentStartPeriod, fixedPeriod) <= 0
+                ? startTime
+                : fixedPeriod.startDate
+
+        onChange({
+            ...period,
+            startTime: startTimeUpdate,
+            endTime: fixedPeriod.endDate,
+        })
     }
 
     let errorMessage = null
@@ -82,7 +229,7 @@ const DateRangePicker = ({ period, dataset, onChange }) => {
         !endDateError &&
         startTime &&
         endTime &&
-        new Date(startTime) > new Date(endTime)
+        startTime > endTime
     ) {
         errorMessage = i18n.t('Start date must be on or before the end date.')
     }
@@ -119,6 +266,69 @@ const DateRangePicker = ({ period, dataset, onChange }) => {
                     <p className={classes.periodError}>{errorMessage}</p>
                 )}
             </div>
+        )
+    }
+
+    if (isFixedRangePeriodType) {
+        return (
+            <>
+                <div className={classes.pickers}>
+                    {fixedPeriodRange.hasCompleteFixedPeriods ? (
+                        <PeriodRangeField
+                            periodType={periodType}
+                            calendar={calendar}
+                            locale={locale}
+                            fromValue={selectedStartPeriodId}
+                            toValue={selectedEndPeriodId}
+                            minPeriodId={fixedPeriodRange.minPeriodId}
+                            maxPeriodId={fixedPeriodRange.maxPeriodId}
+                            fromLabel={i18n.t('Start period')}
+                            toLabel={i18n.t('End period')}
+                            fromDataTest="start-period-input"
+                            toDataTest="end-period-input"
+                            onFromChange={updateStartPeriod}
+                            onToChange={updateEndPeriod}
+                        />
+                    ) : (
+                        <p className={classes.periodError}>
+                            {i18n.t(
+                                'No complete periods are available within the valid range.'
+                            )}
+                        </p>
+                    )}
+                    {datasetFromHourlyData && (
+                        <div className={classes.timezone}>
+                            <TimeZone
+                                period={period}
+                                onChange={handleTimeZoneChange}
+                            />
+                        </div>
+                    )}
+                </div>
+                {periodRange && (
+                    <p className={classes.validRange}>
+                        {i18n.t('Valid range')}:{' '}
+                        <strong>
+                            {getDateStringFromIsoDate({
+                                date: minStandardDate || periodRange.start,
+                                calendar,
+                                locale,
+                            })}
+                        </strong>
+                        {' – '}
+                        <strong>
+                            {getDateStringFromIsoDate({
+                                date: maxStandardDate || periodRange.end,
+                                calendar,
+                                locale,
+                            })}
+                        </strong>
+                    </p>
+                )}
+                {errorMessage && (
+                    <p className={classes.periodError}>{errorMessage}</p>
+                )}
+            </>
         )
     }
 
@@ -197,9 +407,11 @@ const DateRangePicker = ({ period, dataset, onChange }) => {
 DateRangePicker.propTypes = {
     period: PropTypes.shape({
         calendar: PropTypes.string.isRequired,
-        endTime: PropTypes.string.isRequired,
+        endTime: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+            .isRequired,
         periodType: PropTypes.string.isRequired,
-        startTime: PropTypes.string.isRequired,
+        startTime: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+            .isRequired,
         locale: PropTypes.string,
         timeZone: PropTypes.string,
     }).isRequired,

--- a/src/components/import/ImportPage.jsx
+++ b/src/components/import/ImportPage.jsx
@@ -5,6 +5,11 @@ import { useState, useMemo, useEffect, useCallback, useRef } from 'react'
 import { useBlocker } from 'react-router-dom'
 import useImportConfigs from '../../hooks/useImportConfigs.js'
 import useOrgUnits from '../../hooks/useOrgUnits.js'
+import {
+    getCompleteFixedPeriodRange,
+    normalizeStandardDateBoundary,
+} from '../../utils/fixedPeriodRange.js'
+import { normalizeDhis2Calendar } from '../../utils/periodEngine.js'
 import { autoConfigName } from '../../utils/recurringImports.js'
 import {
     getDefaultImportPeriod,
@@ -16,6 +21,7 @@ import {
     formatStandardDate,
     DAILY,
     MONTHLY,
+    WEEKLY,
     YEARLY,
     oneDayInMs,
 } from '../../utils/time.js'
@@ -31,21 +37,40 @@ import PeriodType from './PeriodType.jsx'
 import classes from './styles/ImportPage.module.css'
 
 const maxValues = 50000
+const FIXED_RANGE_PERIOD_TYPES = new Set([WEEKLY, MONTHLY])
+
+const getDatasetPeriodRange = (dataset, periodType) =>
+    dataset?.supportedPeriodTypes?.find((pt) => pt.periodType === periodType)
+        ?.periodRange ||
+    (dataset?.period
+        ? { start: dataset.period, end: dataset.period }
+        : undefined)
 
 const getPeriodRange = ({ calendar, periodType, range }) => {
-    const getDefaultRange = () => {
+    if (!range) {
         const defaultPeriod = getDefaultImportPeriod({ calendar, periodType })
-        return { start: defaultPeriod.startTime, end: defaultPeriod.endTime }
+        return {
+            startTime: defaultPeriod.startTime,
+            endTime: defaultPeriod.endTime,
+        }
     }
-    const validRange = range || getDefaultRange()
+
+    const normalizedStart = normalizeStandardDateBoundary(range.start, 'start')
+    const normalizedEnd = normalizeStandardDateBoundary(range.end, 'end')
+    const validRange = {
+        start: normalizedStart || normalizedEnd,
+        end: normalizedEnd || normalizedStart,
+    }
     // compute end and start depending on requested periodType
     // endTime will generally be converted from standard -> calendar
     // For YEARLY we keep year values (e.g. "2023") so downstream code
     // that expects years for yearly periods continues to work
-    let endTime = fromStandardDate(validRange.end, calendar)
+    let endTime
     let startTime
 
     try {
+        endTime = fromStandardDate(validRange.end, calendar)
+
         if (periodType === DAILY) {
             // subtract 30 days from end
             const endStd = toDateObject(validRange.end)
@@ -95,12 +120,24 @@ const DEFAULT_ORG_UNITS = []
 
 const ImportPage = () => {
     const { systemInfo = {} } = useConfig()
-    const { calendar = 'gregory' } = systemInfo
+    const calendar = normalizeDhis2Calendar(systemInfo.calendar)
     const [dataset, setDataset] = useState()
     const [period, setPeriod] = useState(getDefaultImportPeriod({ calendar }))
     const [orgUnits, setOrgUnits] = useState(DEFAULT_ORG_UNITS)
     const [dataElement, setDataElement] = useState()
     const standardPeriod = useMemo(() => getStandardPeriod(period), [period])
+    const fixedPeriodRangeValid = useMemo(() => {
+        if (!FIXED_RANGE_PERIOD_TYPES.has(period.periodType)) {
+            return true
+        }
+
+        return getCompleteFixedPeriodRange({
+            periodRange: getDatasetPeriodRange(dataset, period.periodType),
+            periodType: period.periodType,
+            calendar: period.calendar,
+            locale: period.locale,
+        }).hasCompleteFixedPeriods
+    }, [dataset, period.calendar, period.locale, period.periodType])
     const [startExtract, setStartExtract] = useState(false)
     const [importDone, setImportDone] = useState(false)
     const [importFeatures, setImportFeatures] = useState(null)
@@ -124,12 +161,16 @@ const ImportPage = () => {
 
     const featureCount = features.length
 
-    const periodCount = useMemo(() => getPeriods(period).length, [period])
+    const periodCount = useMemo(
+        () => getPeriods(standardPeriod).length,
+        [standardPeriod]
+    )
     const valueCount = featureCount * periodCount
 
     // canShowPreview: show preview even during loading (avoids unmounting/remounting)
     const canShowPreview = !!(
         dataset &&
+        fixedPeriodRangeValid &&
         isValidPeriod(standardPeriod) &&
         !featuresError &&
         featureCount > 0 &&
@@ -220,9 +261,19 @@ const ImportPage = () => {
     const updatePeriodType = useCallback(
         (val) => {
             setDataElement(null)
-            updatePeriod({ periodType: val })
+            const { startTime, endTime } = getPeriodRange({
+                range: getDatasetPeriodRange(dataset, val),
+                calendar,
+                periodType: val,
+            })
+
+            updatePeriod({
+                periodType: val,
+                startTime,
+                endTime,
+            })
         },
-        [updatePeriod]
+        [calendar, dataset, updatePeriod]
     )
 
     const updateDataset = useCallback(
@@ -234,19 +285,13 @@ const ImportPage = () => {
                         prev.supportedPeriodTypes.some((pt) => pt.periodRange))
                 )
 
-                const periodType = ds.supportedPeriodTypes.includes(
-                    period.periodType
+                const periodType = ds.supportedPeriodTypes.some(
+                    (pt) => pt.periodType === period.periodType
                 )
                     ? period.periodType
                     : ds.supportedPeriodTypes[0].periodType
 
-                const range =
-                    ds.supportedPeriodTypes.find(
-                        (pt) => pt.periodType === periodType
-                    )?.periodRange ||
-                    (ds.period
-                        ? { start: ds.period, end: ds.period }
-                        : undefined)
+                const range = getDatasetPeriodRange(ds, periodType)
 
                 if (range || prevHasRangeOrPeriod) {
                     const { startTime, endTime } = getPeriodRange({
@@ -398,8 +443,10 @@ const ImportPage = () => {
                         <ImportPreview
                             dataset={dataset.name || ''}
                             periodType={period.periodType || ''}
-                            startDate={period.startTime || ''}
-                            endDate={period.endTime || ''}
+                            startDate={standardPeriod.startTime || ''}
+                            endDate={standardPeriod.endTime || ''}
+                            calendar={period.calendar}
+                            locale={period.locale}
                             featureCount={featureCount}
                             dataElement={dataElement.displayName || ''}
                             totalValues={valueCount}

--- a/src/components/import/ImportPreview.jsx
+++ b/src/components/import/ImportPreview.jsx
@@ -21,6 +21,8 @@ const ImportPreview = ({
     dataElement,
     totalValues,
     orgUnits,
+    calendar,
+    locale,
 }) => {
     const periodTypeObj = getPeriodTypes().find(
         (type) => type.id === periodType
@@ -35,6 +37,8 @@ const ImportPreview = ({
             periodType,
             startTime: startDate,
             endTime: endDate,
+            calendar,
+            locale,
         })
         const firstPeriod = periods[0]
         const lastPeriod = periods.at(-1)
@@ -150,6 +154,8 @@ ImportPreview.propTypes = {
     periodType: PropTypes.string.isRequired,
     startDate: PropTypes.string.isRequired,
     totalValues: PropTypes.number.isRequired,
+    calendar: PropTypes.string,
+    locale: PropTypes.string,
 }
 
 export default ImportPreview

--- a/src/components/import/Period.cy.jsx
+++ b/src/components/import/Period.cy.jsx
@@ -258,7 +258,7 @@ describe('Period', () => {
             setupApiIntercepts('Etc/UTC')
         })
 
-        it('renders start and end date inputs', () => {
+        it('renders start and end date inputs for daily periods', () => {
             cy.mount(
                 <TestWrapper>
                     <Period
@@ -271,6 +271,25 @@ describe('Period', () => {
             cy.wait('@getSystemInfo')
             cy.getByDataTest('start-date-input').should('be.visible')
             cy.getByDataTest('end-date-input').should('be.visible')
+        })
+
+        it('renders fixed period selectors for weekly periods', () => {
+            const period = { ...defaultPeriod, periodType: 'WEEKLY' }
+
+            cy.mount(
+                <TestWrapper>
+                    <Period
+                        period={period}
+                        dataset={dataset}
+                        onChange={mockOnChange}
+                    />
+                </TestWrapper>
+            )
+            cy.wait('@getSystemInfo')
+            cy.getByDataTest('start-period-input').should('be.visible')
+            cy.getByDataTest('end-period-input').should('be.visible')
+            cy.getByDataTest('start-date-input').should('not.exist')
+            cy.getByDataTest('end-date-input').should('not.exist')
         })
     })
 })

--- a/src/components/import/RunConfigModal.cy.jsx
+++ b/src/components/import/RunConfigModal.cy.jsx
@@ -24,6 +24,16 @@ const baseConfig = {
     createdByName: 'Test User',
 }
 
+const dailyConfig = {
+    ...baseConfig,
+    name: 'Daily Temperature',
+    dataset: {
+        ...baseConfig.dataset,
+        supportedPeriodTypes: [{ periodType: 'DAILY' }],
+    },
+    periodType: 'DAILY',
+}
+
 // A valid Point geoFeature that toGeoJson will accept
 const singleFeature = {
     id: 'ou1',
@@ -142,11 +152,11 @@ describe('RunConfigModal', () => {
     })
 
     describe('editing the date range', () => {
-        it('shows date inputs when Change is clicked', () => {
+        it('shows period selectors for monthly configs when Change is clicked', () => {
             mount()
             cy.contains('button', 'Change').click()
-            cy.getByDataTest('start-date-input').should('be.visible')
-            cy.getByDataTest('end-date-input').should('be.visible')
+            cy.getByDataTest('start-period-input').should('be.visible')
+            cy.getByDataTest('end-period-input').should('be.visible')
         })
 
         it('replaces the Change button with Done and Use default range while editing', () => {
@@ -161,7 +171,7 @@ describe('RunConfigModal', () => {
             mount()
             cy.contains('button', 'Change').click()
             cy.contains('button', 'Done').click()
-            cy.getByDataTest('start-date-input').should('not.exist')
+            cy.getByDataTest('start-period-input').should('not.exist')
         })
 
         it('drops the "Since last import" prefix after the range is edited', () => {
@@ -177,11 +187,11 @@ describe('RunConfigModal', () => {
             cy.contains('button', 'Change').click()
             cy.contains('button', 'Use default range').click()
             cy.contains('Since last import').should('be.visible')
-            cy.getByDataTest('start-date-input').should('not.exist')
+            cy.getByDataTest('start-period-input').should('not.exist')
         })
 
         it('shows an error and disables Done when start date is after end date', () => {
-            mount()
+            mount(dailyConfig)
             cy.contains('button', 'Change').click()
             cy.getByDataTest('start-date-input').within(() => {
                 cy.get('input').clear()
@@ -220,7 +230,6 @@ describe('RunConfigModal', () => {
                 dataset: { ...baseConfig.dataset, timeZone: {} },
             }
             mount(configWithTz)
-            cy.wait('@getSystemInfo')
             cy.contains('button', 'Change').click()
             cy.getByDataTest('time-zone-select').should('not.exist')
         })
@@ -263,8 +272,6 @@ describe('RunConfigModal', () => {
                 req.reply({ delay: 3000, body: [singleFeature] })
             }).as('getGeoFeaturesDelayed')
             mount()
-            // Wait for user info so the loading state is triggered
-            cy.wait('@getSystemInfo')
             cy.contains('button', 'Start import').should('be.disabled')
         })
 
@@ -295,8 +302,31 @@ describe('RunConfigModal', () => {
             cy.contains('button', 'Start import').should('be.disabled')
         })
 
+        it('is disabled when no complete fixed periods are available', () => {
+            mount({
+                ...baseConfig,
+                dataset: {
+                    ...baseConfig.dataset,
+                    supportedPeriodTypes: [
+                        {
+                            periodType: 'WEEKLY',
+                            periodRange: {
+                                start: '2026-01-13',
+                                end: '2026-01-15',
+                            },
+                        },
+                    ],
+                },
+                periodType: 'WEEKLY',
+            })
+            cy.contains(
+                'No complete periods are available within the dataset date range.'
+            ).should('be.visible')
+            cy.contains('button', 'Start import').should('be.disabled')
+        })
+
         it('is disabled when the date range is invalid', () => {
-            mount()
+            mount(dailyConfig)
             cy.contains('button', 'Change').click()
             cy.getByDataTest('start-date-input').within(() => {
                 cy.get('input').clear()

--- a/src/components/import/RunConfigModal.jsx
+++ b/src/components/import/RunConfigModal.jsx
@@ -1,3 +1,4 @@
+import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import {
     Button,
@@ -11,7 +12,10 @@ import {
 import PropTypes from 'prop-types'
 import { useCallback, useMemo, useState } from 'react'
 import useOrgUnits from '../../hooks/useOrgUnits.js'
+import useUserLocale from '../../hooks/useUserLocale.js'
+import { getCompleteFixedPeriodRange } from '../../utils/fixedPeriodRange.js'
 import { getOuText } from '../../utils/getOuText.js'
+import { normalizeDhis2Calendar } from '../../utils/periodEngine.js'
 import {
     computeFillGapRange,
     valueCountForRange,
@@ -23,14 +27,44 @@ import {
     YEARLY,
     formatBookmarkDate,
     formatStandardDate,
+    fromStandardDate,
+    getDateStringFromIsoDate,
     getPeriodTypes,
     oneDayInMs,
+    toStandardDate,
 } from '../../utils/time.js'
 import DateRangePicker from './DateRangePicker.jsx'
 import ImportModal from './ImportModal.jsx'
 import classes from './styles/RunConfigModal.module.css'
 
 const MAX_VALUES = 50000
+const FIXED_RANGE_PERIOD_TYPES = new Set([WEEKLY, MONTHLY])
+
+const getDatasetPeriodRange = (dataset, periodType) =>
+    dataset?.supportedPeriodTypes?.find((pt) => pt.periodType === periodType)
+        ?.periodRange
+
+const convertDateSafely = (date, calendar, converter) => {
+    if (!date) {
+        return date
+    }
+
+    try {
+        return converter(date, calendar)
+    } catch {
+        return date
+    }
+}
+
+const toPickerDate = ({ date, calendar, periodType }) =>
+    periodType === YEARLY
+        ? date
+        : convertDateSafely(date, calendar, fromStandardDate)
+
+const toStoredDate = ({ date, calendar, periodType }) =>
+    periodType === YEARLY
+        ? date
+        : convertDateSafely(date, calendar, toStandardDate)
 
 // Fallback range when a config has never successfully imported.
 // Uses the same "last completed period" end boundary as computeFillGapRange.
@@ -66,16 +100,23 @@ const getDefaultRange = (periodType) => {
     }
 }
 
-const formatRangeDisplay = (range) => {
+const formatRangeDisplay = ({ range, calendar, locale }) => {
     if (range.periodType === YEARLY) {
         return `${range.startTime} → ${range.endTime}`
     }
-    return `${formatBookmarkDate(range.startTime)} → ${formatBookmarkDate(
-        range.endTime
-    )}`
+    const formatDate = (date) =>
+        calendar === 'gregory'
+            ? formatBookmarkDate(date)
+            : getDateStringFromIsoDate({ date, calendar, locale })
+
+    return `${formatDate(range.startTime)} → ${formatDate(range.endTime)}`
 }
 
 const RunConfigModal = ({ config, onClose, onRunComplete }) => {
+    const { systemInfo = {} } = useConfig()
+    const { locale } = useUserLocale()
+    const calendar = normalizeDhis2Calendar(systemInfo.calendar)
+
     const {
         features,
         featuresLoading,
@@ -103,16 +144,34 @@ const RunConfigModal = ({ config, onClose, onRunComplete }) => {
         [overrideRange, defaultRange, config.periodType]
     )
 
-    const rangeInvalid = isYearly
-        ? Number.parseInt(range.startTime, 10) >
-          Number.parseInt(range.endTime, 10)
-        : new Date(range.startTime) > new Date(range.endTime)
+    const fixedPeriodRangeValid = useMemo(() => {
+        if (!FIXED_RANGE_PERIOD_TYPES.has(config.periodType)) {
+            return true
+        }
+
+        return getCompleteFixedPeriodRange({
+            periodRange: getDatasetPeriodRange(
+                config.dataset,
+                config.periodType
+            ),
+            periodType: config.periodType,
+            calendar,
+            locale,
+        }).hasCompleteFixedPeriods
+    }, [calendar, config.dataset, config.periodType, locale])
+
+    const rangeInvalid =
+        !fixedPeriodRangeValid ||
+        (isYearly
+            ? Number.parseInt(range.startTime, 10) >
+              Number.parseInt(range.endTime, 10)
+            : new Date(range.startTime) > new Date(range.endTime))
 
     const rangeDisplayText =
         overrideRange || !config.dataUpdatedThrough
-            ? formatRangeDisplay(range)
+            ? formatRangeDisplay({ range, calendar, locale })
             : i18n.t('Since last import ({{range}})', {
-                  range: formatRangeDisplay(range),
+                  range: formatRangeDisplay({ range, calendar, locale }),
                   nsSeparator: ';',
               })
 
@@ -131,12 +190,42 @@ const RunConfigModal = ({ config, onClose, onRunComplete }) => {
         setEditing(false)
     }
 
-    const handleRangeChange = useCallback((updatedPeriod) => {
-        setOverrideRange({
-            startTime: updatedPeriod.startTime,
-            endTime: updatedPeriod.endTime,
-        })
-    }, [])
+    const pickerPeriod = useMemo(
+        () => ({
+            startTime: toPickerDate({
+                date: range.startTime,
+                calendar,
+                periodType: config.periodType,
+            }),
+            endTime: toPickerDate({
+                date: range.endTime,
+                calendar,
+                periodType: config.periodType,
+            }),
+            periodType: config.periodType,
+            calendar,
+            locale,
+        }),
+        [range.startTime, range.endTime, calendar, config.periodType, locale]
+    )
+
+    const handleRangeChange = useCallback(
+        (updatedPeriod) => {
+            setOverrideRange({
+                startTime: toStoredDate({
+                    date: updatedPeriod.startTime,
+                    calendar,
+                    periodType: config.periodType,
+                }),
+                endTime: toStoredDate({
+                    date: updatedPeriod.endTime,
+                    calendar,
+                    periodType: config.periodType,
+                }),
+            })
+        },
+        [calendar, config.periodType]
+    )
 
     const valueCount = useMemo(
         () =>
@@ -261,12 +350,7 @@ const RunConfigModal = ({ config, onClose, onRunComplete }) => {
                                 {editing ? (
                                     <div className={classes.rangeEditor}>
                                         <DateRangePicker
-                                            period={{
-                                                startTime: range.startTime,
-                                                endTime: range.endTime,
-                                                periodType: config.periodType,
-                                                calendar: 'gregory',
-                                            }}
+                                            period={pickerPeriod}
                                             dataset={datasetForPicker}
                                             onChange={handleRangeChange}
                                         />
@@ -321,6 +405,13 @@ const RunConfigModal = ({ config, onClose, onRunComplete }) => {
                                 )}
                             </NoticeBox>
                         )}
+                    {!fixedPeriodRangeValid && (
+                        <NoticeBox warning>
+                            {i18n.t(
+                                'No complete periods are available within the dataset date range.'
+                            )}
+                        </NoticeBox>
+                    )}
                     {exceedsLimit && (
                         <NoticeBox warning>
                             {i18n.t(

--- a/src/components/period-picker/PeriodPicker.jsx
+++ b/src/components/period-picker/PeriodPicker.jsx
@@ -474,11 +474,10 @@ export const PeriodPicker = ({
                         placement="bottom-start"
                         modifiers={[popperOffsetModifier]}
                     >
-                        <div
+                        <dialog
+                            open
                             className={styles.popover}
-                            role="dialog"
                             aria-label={ariaLabel}
-                            tabIndex={-1}
                             onKeyDown={handleEscapeKeyDown}
                         >
                             <div className={styles.header}>
@@ -607,7 +606,7 @@ export const PeriodPicker = ({
                                     )
                                 })}
                             </div>
-                        </div>
+                        </dialog>
                     </Popper>
                 </Layer>
             )}

--- a/src/components/period-picker/PeriodPicker.jsx
+++ b/src/components/period-picker/PeriodPicker.jsx
@@ -1,0 +1,646 @@
+import i18n from '@dhis2/d2-i18n'
+import {
+    IconChevronDown16,
+    IconChevronLeft16,
+    IconChevronRight16,
+    Layer,
+    Popper,
+} from '@dhis2/ui'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+    MONTHLY,
+    WEEKLY,
+    compareFixedPeriods,
+    createFixedPeriodFromPeriodId,
+    generateFixedPeriods,
+    getTodayInCalendar,
+    normalizeDhis2Calendar,
+} from '../../utils/periodEngine.js'
+import styles from './PeriodPicker.module.css'
+
+const getPeriodYear = (periodId) => {
+    if (!periodId) {
+        return undefined
+    }
+
+    const yearMatch = String(periodId).match(/^(\d{4})/)
+    return yearMatch ? Number(yearMatch[1]) : undefined
+}
+
+const createFixedPeriodSafely = (options) => {
+    try {
+        return createFixedPeriodFromPeriodId(options)
+    } catch {
+        return undefined
+    }
+}
+
+const getCurrentCalendarYear = (calendar) =>
+    Number(getTodayInCalendar({ calendar }).substring(0, 4))
+
+const getInitialVisibleYear = ({
+    value,
+    referencePeriodId,
+    maxPeriodId,
+    minPeriodId,
+    calendar,
+    locale,
+}) =>
+    getPeriodYear(value, calendar, locale) ??
+    getPeriodYear(referencePeriodId, calendar, locale) ??
+    getPeriodYear(maxPeriodId, calendar, locale) ??
+    getPeriodYear(minPeriodId, calendar, locale) ??
+    getCurrentCalendarYear(calendar)
+
+const isMonthlyPeriodType = (periodType) => periodType === MONTHLY
+const isWeeklyPeriodType = (periodType) => periodType === WEEKLY
+
+const getMonthlyReferenceLabel = (periodId) =>
+    `${periodId.slice(0, 4)}-${periodId.slice(4, 6)}`
+
+const getMonthlyYear = (periodId) => periodId.slice(0, 4)
+const getMonthlyMonth = (periodId) => Number(periodId.slice(4, 6))
+
+const formatGregorianMonthName = (periodId, locale) => {
+    const year = Number(getMonthlyYear(periodId))
+    const monthIndex = getMonthlyMonth(periodId) - 1
+
+    return new Intl.DateTimeFormat(locale, {
+        month: 'long',
+        timeZone: 'UTC',
+    }).format(new Date(Date.UTC(year, monthIndex, 1)))
+}
+
+const formatGregorianMonthlyLabel = (periodId, locale) => {
+    const year = Number(getMonthlyYear(periodId))
+    const monthIndex = getMonthlyMonth(periodId) - 1
+
+    return new Intl.DateTimeFormat(locale, {
+        month: 'long',
+        timeZone: 'UTC',
+        year: 'numeric',
+    }).format(new Date(Date.UTC(year, monthIndex, 1)))
+}
+
+const getFallbackMonthlyLabel = (period, calendar, locale) => {
+    if (calendar === 'gregory' || calendar === 'iso8601') {
+        return formatGregorianMonthlyLabel(period.id, locale)
+    }
+
+    return i18n.t('Month {{month}}, {{year}}', {
+        month: getMonthlyMonth(period.id),
+        year: getMonthlyYear(period.id),
+    })
+}
+
+const getFallbackMonthlyCellLabel = (period, calendar, locale) => {
+    if (calendar === 'gregory' || calendar === 'iso8601') {
+        return formatGregorianMonthName(period.id, locale)
+    }
+
+    return i18n.t('Month {{month}}', {
+        month: getMonthlyMonth(period.id),
+    })
+}
+
+const removeMonthlyYearFromLabel = (label, periodId) => {
+    const labelWithoutYear = label
+        .replace(getMonthlyYear(periodId), '')
+        .replace(/\s+/g, ' ')
+        .trim()
+
+    return labelWithoutYear || label
+}
+
+const getPeriodPrimaryLabel = (period, calendar, locale) => {
+    if (!period) {
+        return undefined
+    }
+
+    const label = (period.displayName || period.name)?.trim()
+    if (
+        label &&
+        isMonthlyPeriodType(period.periodType) &&
+        label === period.id.slice(0, 4)
+    ) {
+        return getFallbackMonthlyLabel(period, calendar, locale)
+    }
+
+    return label || period.id
+}
+
+const getPeriodCellPrimaryLabel = (period, calendar, locale) => {
+    if (!isMonthlyPeriodType(period.periodType)) {
+        return getPeriodPrimaryLabel(period, calendar, locale)
+    }
+
+    const label = (period.displayName || period.name)?.trim()
+    if (label && label !== getMonthlyYear(period.id)) {
+        return removeMonthlyYearFromLabel(label, period.id)
+    }
+
+    return getFallbackMonthlyCellLabel(period, calendar, locale)
+}
+
+const getPeriodSecondaryLabel = (period) => {
+    if (isMonthlyPeriodType(period.periodType)) {
+        return getMonthlyReferenceLabel(period.id)
+    }
+
+    if (isWeeklyPeriodType(period.periodType)) {
+        return undefined
+    }
+
+    return period.id
+}
+
+const YEAR_SELECT_PAST_YEARS = 100
+const YEAR_SELECT_FUTURE_YEARS = 25
+const NEPALI_MIN_YEAR = 1971
+const NEPALI_MAX_YEAR = 2099
+
+const getYearFromPeriod = (period) =>
+    period ? Number(period.id.substring(0, 4)) : undefined
+
+const getBoundedYear = ({ year, minYear, maxYear, calendar }) => {
+    let boundedYear = year
+
+    if (calendar === 'nepali') {
+        boundedYear = Math.max(NEPALI_MIN_YEAR, boundedYear)
+        boundedYear = Math.min(NEPALI_MAX_YEAR, boundedYear)
+    }
+
+    if (minYear !== undefined) {
+        boundedYear = Math.max(minYear, boundedYear)
+    }
+
+    if (maxYear !== undefined) {
+        boundedYear = Math.min(maxYear, boundedYear)
+    }
+
+    return boundedYear
+}
+
+const getYearSelectOptions = ({ visibleYear, minYear, maxYear, calendar }) => {
+    let startYear = visibleYear - YEAR_SELECT_PAST_YEARS
+    let endYear = visibleYear + YEAR_SELECT_FUTURE_YEARS
+
+    if (calendar === 'nepali') {
+        startYear = Math.max(startYear, NEPALI_MIN_YEAR)
+        endYear = Math.min(endYear, NEPALI_MAX_YEAR)
+    }
+
+    if (minYear !== undefined) {
+        startYear = Math.max(startYear, minYear)
+    }
+
+    if (maxYear !== undefined) {
+        endYear = Math.min(endYear, maxYear)
+    }
+
+    if (startYear > endYear) {
+        const boundedYear = getBoundedYear({
+            year: visibleYear,
+            minYear,
+            maxYear,
+            calendar,
+        })
+        return [boundedYear]
+    }
+
+    return Array.from(
+        { length: endYear - startYear + 1 },
+        (_, index) => startYear + index
+    )
+}
+
+const popperOffsetModifier = {
+    name: 'offset',
+    options: {
+        offset: [0, 2],
+    },
+}
+
+const focusTrigger = (trigger) => {
+    if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(() => trigger.current?.focus())
+        return
+    }
+
+    trigger.current?.focus()
+}
+
+export const PeriodPicker = ({
+    value,
+    periodType,
+    calendar,
+    locale = 'en',
+    minPeriodId,
+    maxPeriodId,
+    referencePeriodId,
+    isPeriodDisabled,
+    disabled,
+    error,
+    placeholder = i18n.t('Select period'),
+    ariaLabel = i18n.t('Select period'),
+    dataTest,
+    onChange,
+}) => {
+    const normalizedCalendar = normalizeDhis2Calendar(calendar)
+    const anchorRef = useRef(null)
+    const triggerRef = useRef(null)
+    const [open, setOpen] = useState(false)
+    const [visibleYear, setVisibleYear] = useState(() =>
+        getInitialVisibleYear({
+            value,
+            referencePeriodId,
+            minPeriodId,
+            maxPeriodId,
+            calendar: normalizedCalendar,
+            locale,
+        })
+    )
+
+    const selectedPeriod = useMemo(
+        () =>
+            value
+                ? createFixedPeriodSafely({
+                      periodId: value,
+                      calendar: normalizedCalendar,
+                      locale,
+                  })
+                : undefined,
+        [normalizedCalendar, locale, value]
+    )
+
+    const minPeriod = useMemo(
+        () =>
+            minPeriodId
+                ? createFixedPeriodSafely({
+                      periodId: minPeriodId,
+                      calendar: normalizedCalendar,
+                      locale,
+                  })
+                : undefined,
+        [normalizedCalendar, locale, minPeriodId]
+    )
+
+    const maxPeriod = useMemo(
+        () =>
+            maxPeriodId
+                ? createFixedPeriodSafely({
+                      periodId: maxPeriodId,
+                      calendar: normalizedCalendar,
+                      locale,
+                  })
+                : undefined,
+        [normalizedCalendar, locale, maxPeriodId]
+    )
+
+    const minYear = getYearFromPeriod(minPeriod)
+    const maxYear = getYearFromPeriod(maxPeriod)
+    const boundedVisibleYear = getBoundedYear({
+        year: visibleYear,
+        minYear,
+        maxYear,
+        calendar: normalizedCalendar,
+    })
+
+    const periods = useMemo(() => {
+        try {
+            return generateFixedPeriods({
+                year: boundedVisibleYear,
+                periodType,
+                calendar: normalizedCalendar,
+                locale,
+            })
+        } catch {
+            return []
+        }
+    }, [boundedVisibleYear, normalizedCalendar, locale, periodType])
+
+    const yearOptions = useMemo(
+        () =>
+            getYearSelectOptions({
+                visibleYear: boundedVisibleYear,
+                minYear,
+                maxYear,
+                calendar: normalizedCalendar,
+            }),
+        [boundedVisibleYear, normalizedCalendar, maxYear, minYear]
+    )
+
+    useEffect(() => {
+        if (boundedVisibleYear !== visibleYear) {
+            setVisibleYear(boundedVisibleYear)
+        }
+    }, [boundedVisibleYear, visibleYear])
+
+    useEffect(() => {
+        const periodId = value || referencePeriodId
+        if (!periodId) {
+            return
+        }
+
+        const periodYear = getPeriodYear(periodId)
+        if (periodYear === undefined) {
+            return
+        }
+
+        setVisibleYear(
+            getBoundedYear({
+                year: periodYear,
+                minYear,
+                maxYear,
+                calendar: normalizedCalendar,
+            })
+        )
+    }, [maxYear, minYear, normalizedCalendar, referencePeriodId, value])
+
+    const closeAndFocusTrigger = () => {
+        setOpen(false)
+        focusTrigger(triggerRef)
+    }
+
+    const handleEscapeKeyDown = (event) => {
+        if (event.key !== 'Escape' || !open) {
+            return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+        event.nativeEvent?.stopImmediatePropagation?.()
+        closeAndFocusTrigger()
+    }
+
+    const goToPreviousYear = () => {
+        setVisibleYear((year) =>
+            getBoundedYear({
+                year: year - 1,
+                minYear,
+                maxYear,
+                calendar: normalizedCalendar,
+            })
+        )
+    }
+
+    const goToNextYear = () => {
+        setVisibleYear((year) =>
+            getBoundedYear({
+                year: year + 1,
+                minYear,
+                maxYear,
+                calendar: normalizedCalendar,
+            })
+        )
+    }
+
+    const minNavigableYear = getBoundedYear({
+        year: Number.NEGATIVE_INFINITY,
+        minYear,
+        maxYear,
+        calendar: normalizedCalendar,
+    })
+    const maxNavigableYear = getBoundedYear({
+        year: Number.POSITIVE_INFINITY,
+        minYear,
+        maxYear,
+        calendar: normalizedCalendar,
+    })
+    const canNavigatePrevious =
+        minNavigableYear === Number.NEGATIVE_INFINITY ||
+        boundedVisibleYear > minNavigableYear
+    const canNavigateNext =
+        maxNavigableYear === Number.POSITIVE_INFINITY ||
+        boundedVisibleYear < maxNavigableYear
+
+    const periodIsDisabled = (period) => {
+        if (minPeriod && compareFixedPeriods(period, minPeriod) < 0) {
+            return true
+        }
+
+        if (maxPeriod && compareFixedPeriods(period, maxPeriod) > 0) {
+            return true
+        }
+
+        return isPeriodDisabled?.(period) ?? false
+    }
+
+    const handleSelect = (period) => {
+        if (periodIsDisabled(period)) {
+            return
+        }
+
+        onChange(period)
+        closeAndFocusTrigger()
+    }
+
+    const triggerLabel =
+        getPeriodPrimaryLabel(selectedPeriod, normalizedCalendar, locale) ??
+        placeholder
+    const accessibleTriggerLabel = selectedPeriod
+        ? `${ariaLabel}: ${triggerLabel}`
+        : ariaLabel
+
+    return (
+        <div className={styles.container} ref={anchorRef}>
+            <button
+                type="button"
+                ref={triggerRef}
+                className={cx(styles.trigger, error && styles.triggerError)}
+                disabled={disabled}
+                aria-label={accessibleTriggerLabel}
+                aria-expanded={open}
+                aria-invalid={error || undefined}
+                data-test={dataTest}
+                onClick={() => setOpen((prev) => !prev)}
+                onKeyDown={handleEscapeKeyDown}
+            >
+                <span
+                    className={
+                        selectedPeriod
+                            ? styles.triggerValue
+                            : styles.placeholder
+                    }
+                >
+                    {triggerLabel}
+                </span>
+                <IconChevronDown16 />
+            </button>
+
+            {open && (
+                <Layer onBackdropClick={closeAndFocusTrigger}>
+                    <Popper
+                        reference={anchorRef}
+                        placement="bottom-start"
+                        modifiers={[popperOffsetModifier]}
+                    >
+                        <div
+                            className={styles.popover}
+                            onKeyDown={handleEscapeKeyDown}
+                        >
+                            <div className={styles.header}>
+                                <div className={styles.yearNavigation}>
+                                    <div
+                                        className={
+                                            styles.yearNavigationPrevious
+                                        }
+                                    >
+                                        <button
+                                            type="button"
+                                            className={styles.iconButton}
+                                            aria-label={i18n.t('Previous year')}
+                                            data-test={
+                                                dataTest
+                                                    ? `${dataTest}-previous-year`
+                                                    : undefined
+                                            }
+                                            disabled={!canNavigatePrevious}
+                                            onClick={goToPreviousYear}
+                                        >
+                                            <IconChevronLeft16 />
+                                        </button>
+                                    </div>
+                                    <div className={styles.yearSelectWrapper}>
+                                        <select
+                                            className={styles.yearSelect}
+                                            aria-label={i18n.t('Select year')}
+                                            data-test={
+                                                dataTest
+                                                    ? `${dataTest}-visible-year`
+                                                    : undefined
+                                            }
+                                            value={boundedVisibleYear}
+                                            onChange={(event) =>
+                                                setVisibleYear(
+                                                    Number(event.target.value)
+                                                )
+                                            }
+                                        >
+                                            {yearOptions.map((year) => (
+                                                <option key={year} value={year}>
+                                                    {year}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <IconChevronDown16
+                                            className={styles.yearSelectIcon}
+                                        />
+                                    </div>
+                                    <div className={styles.yearNavigationNext}>
+                                        <button
+                                            type="button"
+                                            className={styles.iconButton}
+                                            aria-label={i18n.t('Next year')}
+                                            data-test={
+                                                dataTest
+                                                    ? `${dataTest}-next-year`
+                                                    : undefined
+                                            }
+                                            disabled={!canNavigateNext}
+                                            onClick={goToNextYear}
+                                        >
+                                            <IconChevronRight16 />
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div
+                                className={
+                                    isMonthlyPeriodType(periodType)
+                                        ? styles.monthGrid
+                                        : styles.weekList
+                                }
+                            >
+                                {periods.map((period) => {
+                                    const selected =
+                                        selectedPeriod?.id === period.id
+                                    const periodDisabled =
+                                        periodIsDisabled(period)
+                                    const secondaryLabel =
+                                        getPeriodSecondaryLabel(period)
+                                    const buttonClassName = cx(
+                                        selected
+                                            ? styles.periodButtonSelected
+                                            : styles.periodButton,
+                                        !secondaryLabel &&
+                                            styles.periodButtonSingleLine
+                                    )
+
+                                    return (
+                                        <button
+                                            type="button"
+                                            key={period.id}
+                                            className={buttonClassName}
+                                            disabled={periodDisabled}
+                                            aria-pressed={selected}
+                                            title={getPeriodPrimaryLabel(
+                                                period,
+                                                normalizedCalendar,
+                                                locale
+                                            )}
+                                            data-test={
+                                                dataTest
+                                                    ? `${dataTest}-option-${period.id}`
+                                                    : undefined
+                                            }
+                                            onClick={() => handleSelect(period)}
+                                        >
+                                            <span className={styles.periodName}>
+                                                {getPeriodCellPrimaryLabel(
+                                                    period,
+                                                    normalizedCalendar,
+                                                    locale
+                                                )}
+                                            </span>
+                                            {secondaryLabel && (
+                                                <span
+                                                    className={styles.periodId}
+                                                >
+                                                    {secondaryLabel}
+                                                </span>
+                                            )}
+                                        </button>
+                                    )
+                                })}
+                            </div>
+                        </div>
+                    </Popper>
+                </Layer>
+            )}
+        </div>
+    )
+}
+
+const fixedPeriodShape = PropTypes.shape({
+    endDate: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    periodType: PropTypes.string.isRequired,
+    startDate: PropTypes.string.isRequired,
+    displayName: PropTypes.string,
+    name: PropTypes.string,
+})
+
+PeriodPicker.propTypes = {
+    calendar: PropTypes.string.isRequired,
+    periodType: PropTypes.oneOf([WEEKLY, MONTHLY]).isRequired,
+    onChange: PropTypes.func.isRequired,
+    ariaLabel: PropTypes.string,
+    dataTest: PropTypes.string,
+    disabled: PropTypes.bool,
+    error: PropTypes.bool,
+    isPeriodDisabled: PropTypes.func,
+    locale: PropTypes.string,
+    maxPeriodId: PropTypes.string,
+    minPeriodId: PropTypes.string,
+    placeholder: PropTypes.string,
+    referencePeriodId: PropTypes.string,
+    value: PropTypes.string,
+}
+
+PeriodPicker.fixedPeriodShape = fixedPeriodShape
+
+export default PeriodPicker

--- a/src/components/period-picker/PeriodPicker.jsx
+++ b/src/components/period-picker/PeriodPicker.jsx
@@ -25,7 +25,7 @@ const getPeriodYear = (periodId) => {
         return undefined
     }
 
-    const yearMatch = String(periodId).match(/^(\d{4})/)
+    const yearMatch = /^(\d{4})/.exec(String(periodId))
     return yearMatch ? Number(yearMatch[1]) : undefined
 }
 
@@ -46,12 +46,11 @@ const getInitialVisibleYear = ({
     maxPeriodId,
     minPeriodId,
     calendar,
-    locale,
 }) =>
-    getPeriodYear(value, calendar, locale) ??
-    getPeriodYear(referencePeriodId, calendar, locale) ??
-    getPeriodYear(maxPeriodId, calendar, locale) ??
-    getPeriodYear(minPeriodId, calendar, locale) ??
+    getPeriodYear(value) ??
+    getPeriodYear(referencePeriodId) ??
+    getPeriodYear(maxPeriodId) ??
+    getPeriodYear(minPeriodId) ??
     getCurrentCalendarYear(calendar)
 
 const isMonthlyPeriodType = (periodType) => periodType === MONTHLY
@@ -259,7 +258,6 @@ export const PeriodPicker = ({
             minPeriodId,
             maxPeriodId,
             calendar: normalizedCalendar,
-            locale,
         })
     )
 
@@ -453,7 +451,6 @@ export const PeriodPicker = ({
                 disabled={disabled}
                 aria-label={accessibleTriggerLabel}
                 aria-expanded={open}
-                aria-invalid={error || undefined}
                 data-test={dataTest}
                 onClick={() => setOpen((prev) => !prev)}
                 onKeyDown={handleEscapeKeyDown}
@@ -479,6 +476,9 @@ export const PeriodPicker = ({
                     >
                         <div
                             className={styles.popover}
+                            role="dialog"
+                            aria-label={ariaLabel}
+                            tabIndex={-1}
                             onKeyDown={handleEscapeKeyDown}
                         >
                             <div className={styles.header}>

--- a/src/components/period-picker/PeriodPicker.module.css
+++ b/src/components/period-picker/PeriodPicker.module.css
@@ -1,0 +1,262 @@
+.container {
+    inline-size: 100%;
+}
+
+.trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacers-dp8);
+    inline-size: 100%;
+    min-block-size: 40px;
+    padding: 8px 8px 8px 11px;
+    color: var(--colors-grey900);
+    background: var(--colors-white);
+    border: 1px solid var(--colors-grey500);
+    border-radius: 3px;
+    box-shadow: inset 0 1px 2px 0 rgba(48, 54, 60, 0.1);
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 16px;
+    text-align: start;
+}
+
+.trigger:focus {
+    outline: none;
+    border-color: var(--colors-teal400);
+}
+
+.trigger:disabled {
+    color: var(--colors-grey600);
+    background: var(--colors-grey100);
+    cursor: not-allowed;
+}
+
+.triggerError {
+    border-color: var(--colors-red500);
+}
+
+.triggerValue,
+.placeholder {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.placeholder {
+    color: var(--colors-grey600);
+}
+
+.popover {
+    inline-size: min(300px, calc(100vw - 32px));
+    overflow: hidden;
+    padding: 0;
+    font-family: Roboto, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    background: var(--colors-white);
+    border-radius: 3px;
+    box-shadow: 0 4px 12px rgba(12, 14, 16, 0.15),
+        0 0 0 1px rgba(12, 14, 16, 0.05);
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--spacers-dp4);
+    width: 100%;
+    padding: var(--spacers-dp4);
+    font-size: 1em;
+    border-block-end: 1px solid var(--colors-grey300);
+    background: var(--colors-grey050);
+}
+
+.yearNavigation {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: var(--colors-white);
+    border: 1px solid var(--colors-grey300);
+    border-radius: 3px;
+}
+
+.yearNavigationPrevious {
+    border-inline-end: 1px solid var(--colors-grey300);
+}
+
+.yearNavigationNext {
+    border-inline-start: 1px solid var(--colors-grey300);
+}
+
+.yearNavigationPrevious,
+.yearNavigationNext,
+.yearSelectWrapper {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.yearNavigationPrevious,
+.yearNavigationNext {
+    inline-size: 20px;
+    flex-shrink: 0;
+}
+
+.yearSelectWrapper {
+    position: relative;
+    flex: 0 1 auto;
+    overflow: hidden;
+}
+
+.yearSelect {
+    inline-size: 100%;
+    max-inline-size: 100%;
+    block-size: 24px;
+    box-sizing: border-box;
+    padding-block-start: 1px;
+    padding-block-end: 0;
+    padding-inline-start: var(--spacers-dp4);
+    padding-inline-end: var(--spacers-dp16);
+    overflow: hidden;
+    color: var(--colors-grey800);
+    background: none;
+    border: 0;
+    border-radius: 0;
+    appearance: none;
+    text-align: start;
+    white-space: nowrap;
+}
+
+.yearSelect:hover {
+    background: var(--colors-grey100);
+    cursor: pointer;
+}
+
+.yearSelect:focus {
+    background: var(--colors-grey100);
+    outline-color: var(--colors-grey700);
+}
+
+.yearSelectIcon {
+    position: absolute;
+    inset-inline-end: 0;
+    pointer-events: none;
+    color: var(--colors-grey700);
+}
+
+.iconButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 20px;
+    block-size: 24px;
+    padding: 4px 2px;
+    color: var(--colors-grey700);
+    background: none;
+    border: 0;
+}
+
+.iconButton:hover {
+    color: var(--colors-grey900);
+    background-color: var(--colors-grey100);
+    cursor: pointer;
+}
+
+.iconButton:disabled {
+    color: var(--colors-grey500);
+    background: none;
+    cursor: not-allowed;
+}
+
+.monthGrid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 2px;
+    padding: var(--spacers-dp4);
+}
+
+.weekList {
+    display: grid;
+    gap: 2px;
+    max-block-size: 272px;
+    overflow-y: auto;
+    padding: var(--spacers-dp4);
+}
+
+.periodButton,
+.periodButtonSelected {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    gap: 1px;
+    min-block-size: 40px;
+    padding: 4px 7px;
+    color: var(--colors-grey900);
+    background: var(--colors-white);
+    border: 2px solid transparent;
+    border-radius: 3px;
+    cursor: pointer;
+    font: inherit;
+    line-height: 18px;
+    text-align: start;
+}
+
+.periodButton:hover,
+.periodButton:focus {
+    background: var(--colors-grey100);
+    outline: none;
+}
+
+.periodButton:hover .periodName,
+.periodButton:focus .periodName {
+    text-decoration: underline;
+}
+
+.periodButton:active {
+    background: var(--colors-grey300);
+}
+
+.periodButtonSelected {
+    color: var(--colors-white);
+    background: var(--colors-teal700);
+}
+
+.periodButtonSingleLine {
+    justify-content: center;
+    min-block-size: 34px;
+    padding-block: 3px;
+}
+
+.periodButton:disabled,
+.periodButtonSelected:disabled {
+    color: var(--colors-grey500);
+    background: var(--colors-white);
+    border-color: transparent;
+    cursor: not-allowed;
+}
+
+.periodName {
+    overflow: hidden;
+    color: inherit;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 17px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.periodId {
+    color: var(--colors-grey700);
+    font-size: 12px;
+    line-height: 14px;
+}
+
+.periodButtonSelected .periodId {
+    color: var(--colors-teal100);
+}
+
+.periodButton:disabled .periodId,
+.periodButtonSelected:disabled .periodId {
+    color: var(--colors-grey500);
+}

--- a/src/components/period-picker/PeriodPicker.module.css
+++ b/src/components/period-picker/PeriodPicker.module.css
@@ -55,7 +55,9 @@
     font-size: 14px;
     font-weight: 400;
     background: var(--colors-white);
+    border: 0;
     border-radius: 3px;
+    margin: 0;
     box-shadow: 0 4px 12px rgba(12, 14, 16, 0.15),
         0 0 0 1px rgba(12, 14, 16, 0.05);
 }

--- a/src/components/period-picker/PeriodRangeField.jsx
+++ b/src/components/period-picker/PeriodRangeField.jsx
@@ -1,0 +1,169 @@
+import i18n from '@dhis2/d2-i18n'
+import { Label } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import { useMemo } from 'react'
+import {
+    MONTHLY,
+    WEEKLY,
+    compareFixedPeriods,
+    createFixedPeriodFromPeriodId,
+    normalizeDhis2Calendar,
+} from '../../utils/periodEngine.js'
+import { PeriodPicker } from './PeriodPicker.jsx'
+import styles from './PeriodRangeField.module.css'
+
+const getPeriod = ({ periodId, calendar, locale }) =>
+    periodId ? createPeriodSafely({ periodId, calendar, locale }) : undefined
+
+const createPeriodSafely = (options) => {
+    try {
+        return createFixedPeriodFromPeriodId(options)
+    } catch {
+        return undefined
+    }
+}
+
+const getRangeError = ({ fromPeriod, toPeriod, fallbackError, enabled }) => {
+    if (fallbackError || !enabled || !fromPeriod || !toPeriod) {
+        return fallbackError
+    }
+
+    if (compareFixedPeriods(fromPeriod, toPeriod) > 0) {
+        return i18n.t('Start period must be before or equal to end period.')
+    }
+
+    return null
+}
+
+export const PeriodRangeField = ({
+    periodType,
+    calendar,
+    locale = 'en',
+    fromValue,
+    toValue,
+    minPeriodId,
+    maxPeriodId,
+    disabled,
+    error,
+    fromLabel = i18n.t('From period'),
+    toLabel = i18n.t('To period'),
+    fromError,
+    toError,
+    fromDataTest,
+    toDataTest,
+    onFromChange,
+    onToChange,
+}) => {
+    const normalizedCalendar = normalizeDhis2Calendar(calendar)
+    const fromPeriod = useMemo(
+        () =>
+            getPeriod({
+                periodId: fromValue,
+                calendar: normalizedCalendar,
+                locale,
+            }),
+        [fromValue, locale, normalizedCalendar]
+    )
+    const toPeriod = useMemo(
+        () =>
+            getPeriod({
+                periodId: toValue,
+                calendar: normalizedCalendar,
+                locale,
+            }),
+        [toValue, locale, normalizedCalendar]
+    )
+    const invalidRange = Boolean(
+        fromPeriod && toPeriod && compareFixedPeriods(fromPeriod, toPeriod) > 0
+    )
+    const resolvedFromError = getRangeError({
+        fromPeriod,
+        toPeriod,
+        fallbackError: fromError,
+        enabled: error,
+    })
+    const resolvedToError = getRangeError({
+        fromPeriod,
+        toPeriod,
+        fallbackError: toError,
+        enabled: error,
+    })
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.field}>
+                <Label>{fromLabel}</Label>
+                <PeriodPicker
+                    value={fromValue}
+                    periodType={periodType}
+                    calendar={normalizedCalendar}
+                    locale={locale}
+                    minPeriodId={minPeriodId}
+                    maxPeriodId={maxPeriodId}
+                    referencePeriodId={toValue}
+                    disabled={disabled}
+                    error={Boolean(resolvedFromError || invalidRange)}
+                    dataTest={fromDataTest}
+                    ariaLabel={fromLabel}
+                    isPeriodDisabled={(period) =>
+                        toPeriod
+                            ? compareFixedPeriods(period, toPeriod) > 0
+                            : false
+                    }
+                    onChange={onFromChange}
+                />
+                {resolvedFromError && (
+                    <p className={styles.errorText}>{resolvedFromError}</p>
+                )}
+            </div>
+
+            <div className={styles.field}>
+                <Label>{toLabel}</Label>
+                <PeriodPicker
+                    value={toValue}
+                    periodType={periodType}
+                    calendar={normalizedCalendar}
+                    locale={locale}
+                    minPeriodId={minPeriodId}
+                    maxPeriodId={maxPeriodId}
+                    referencePeriodId={fromValue}
+                    disabled={disabled}
+                    error={Boolean(resolvedToError || invalidRange)}
+                    dataTest={toDataTest}
+                    ariaLabel={toLabel}
+                    isPeriodDisabled={(period) =>
+                        fromPeriod
+                            ? compareFixedPeriods(period, fromPeriod) < 0
+                            : false
+                    }
+                    onChange={onToChange}
+                />
+                {resolvedToError && (
+                    <p className={styles.errorText}>{resolvedToError}</p>
+                )}
+            </div>
+        </div>
+    )
+}
+
+PeriodRangeField.propTypes = {
+    calendar: PropTypes.string.isRequired,
+    periodType: PropTypes.oneOf([WEEKLY, MONTHLY]).isRequired,
+    onFromChange: PropTypes.func.isRequired,
+    onToChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool,
+    error: PropTypes.bool,
+    fromDataTest: PropTypes.string,
+    fromError: PropTypes.string,
+    fromLabel: PropTypes.string,
+    fromValue: PropTypes.string,
+    locale: PropTypes.string,
+    maxPeriodId: PropTypes.string,
+    minPeriodId: PropTypes.string,
+    toDataTest: PropTypes.string,
+    toError: PropTypes.string,
+    toLabel: PropTypes.string,
+    toValue: PropTypes.string,
+}
+
+export default PeriodRangeField

--- a/src/components/period-picker/PeriodRangeField.module.css
+++ b/src/components/period-picker/PeriodRangeField.module.css
@@ -1,0 +1,24 @@
+.container {
+    display: flex;
+    gap: var(--spacers-dp16);
+    margin-block-start: var(--spacers-dp16);
+}
+
+.field {
+    flex: 1;
+    min-inline-size: 0;
+}
+
+.errorText {
+    color: var(--colors-red700);
+    font-size: 14px;
+    font-weight: 700;
+    margin-block-start: var(--spacers-dp4);
+    margin-block-end: 0;
+}
+
+@media (max-width: 640px) {
+    .container {
+        flex-direction: column;
+    }
+}

--- a/src/components/period-picker/index.js
+++ b/src/components/period-picker/index.js
@@ -1,0 +1,2 @@
+export { PeriodPicker } from './PeriodPicker.jsx'
+export { PeriodRangeField } from './PeriodRangeField.jsx'

--- a/src/utils/__tests__/fixedPeriodRange.test.js
+++ b/src/utils/__tests__/fixedPeriodRange.test.js
@@ -1,0 +1,31 @@
+import { getCompleteFixedPeriodRange } from '../fixedPeriodRange.js'
+import { WEEKLY } from '../time.js'
+
+describe('fixed period range utils', () => {
+    it('computes one-sided maximum bounds independently', () => {
+        const result = getCompleteFixedPeriodRange({
+            periodRange: { end: '2026-01-18' },
+            periodType: WEEKLY,
+            calendar: 'gregory',
+            locale: 'en',
+        })
+
+        expect(result.hasCompleteFixedPeriods).toEqual(true)
+        expect(result.minPeriodId).toBeUndefined()
+        expect(result.maxPeriodId).toEqual('2026W3')
+    })
+
+    it('reports no complete fixed periods when bounds cross after snapping', () => {
+        const result = getCompleteFixedPeriodRange({
+            periodRange: {
+                start: '2026-01-13',
+                end: '2026-01-15',
+            },
+            periodType: WEEKLY,
+            calendar: 'gregory',
+            locale: 'en',
+        })
+
+        expect(result.hasCompleteFixedPeriods).toEqual(false)
+    })
+})

--- a/src/utils/fixedPeriodRange.js
+++ b/src/utils/fixedPeriodRange.js
@@ -1,0 +1,261 @@
+import {
+    compareFixedPeriods,
+    getAdjacentFixedPeriod,
+    getFixedPeriodByDate,
+} from './periodEngine.js'
+import { fromStandardDate } from './time.js'
+
+const getIsoWeekStartDate = (year, week) => {
+    const simple = new Date(Date.UTC(year, 0, 4))
+    const dayOfWeek = simple.getUTCDay() || 7
+    const isoWeek1Start = new Date(simple)
+    isoWeek1Start.setUTCDate(simple.getUTCDate() - dayOfWeek + 1)
+
+    const date = new Date(isoWeek1Start)
+    date.setUTCDate(date.getUTCDate() + (week - 1) * 7)
+    return date
+}
+
+export const normalizeStandardDateBoundary = (input, boundary) => {
+    if (!input || typeof input !== 'string') {
+        return null
+    }
+
+    if (/^\d{4}$/.test(input)) {
+        return boundary === 'end' ? `${input}-12-31` : `${input}-01-01`
+    }
+
+    const monthMatch = /^(\d{4})-(\d{2})$/.exec(input)
+    if (monthMatch) {
+        const [, year, month] = monthMatch
+        if (boundary === 'end') {
+            return new Date(Date.UTC(Number(year), Number(month), 0))
+                .toISOString()
+                .slice(0, 10)
+        }
+        return `${input}-01`
+    }
+
+    const weekMatch = /^(\d{4})-?W0?(\d{1,2})$/.exec(input)
+    if (weekMatch) {
+        const [, yearStr, weekStr] = weekMatch
+        const date = getIsoWeekStartDate(
+            Number.parseInt(yearStr, 10),
+            Number.parseInt(weekStr, 10)
+        )
+
+        if (boundary === 'end') {
+            date.setUTCDate(date.getUTCDate() + 6)
+        }
+
+        return date.toISOString().slice(0, 10)
+    }
+
+    if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+        return input
+    }
+
+    return null
+}
+
+const toCalendarDate = (standardDate, calendar) => {
+    if (!standardDate) {
+        return null
+    }
+
+    try {
+        return fromStandardDate(standardDate, calendar)
+    } catch {
+        return null
+    }
+}
+
+export const getCalendarDateBoundaries = ({ periodRange, calendar }) => {
+    const minStandardDate = normalizeStandardDateBoundary(
+        periodRange?.start,
+        'start'
+    )
+    const maxStandardDate = normalizeStandardDateBoundary(
+        periodRange?.end,
+        'end'
+    )
+
+    return {
+        minStandardDate,
+        maxStandardDate,
+        minCalendarDate: toCalendarDate(minStandardDate, calendar),
+        maxCalendarDate: toCalendarDate(maxStandardDate, calendar),
+    }
+}
+
+export const getFixedPeriodForDate = ({
+    date,
+    periodType,
+    calendar,
+    locale,
+}) => {
+    try {
+        return getFixedPeriodByDate({
+            periodType,
+            date,
+            calendar,
+            locale,
+        })
+    } catch {
+        return null
+    }
+}
+
+const getFirstFullPeriodOnOrAfter = ({
+    date,
+    periodType,
+    calendar,
+    locale,
+}) => {
+    const period = getFixedPeriodForDate({
+        date,
+        periodType,
+        calendar,
+        locale,
+    })
+
+    if (!period) {
+        return null
+    }
+
+    return period.startDate < date
+        ? getAdjacentFixedPeriod({ period, steps: 1, calendar, locale })
+        : period
+}
+
+const getLastFullPeriodOnOrBefore = ({
+    date,
+    periodType,
+    calendar,
+    locale,
+}) => {
+    const period = getFixedPeriodForDate({
+        date,
+        periodType,
+        calendar,
+        locale,
+    })
+
+    if (!period) {
+        return null
+    }
+
+    return period.endDate > date
+        ? getAdjacentFixedPeriod({ period, steps: -1, calendar, locale })
+        : period
+}
+
+export const getCompleteFixedPeriodRange = ({
+    periodRange,
+    periodType,
+    calendar,
+    locale,
+}) => {
+    const {
+        minStandardDate,
+        maxStandardDate,
+        minCalendarDate,
+        maxCalendarDate,
+    } = getCalendarDateBoundaries({ periodRange, calendar })
+
+    const minPeriod = minCalendarDate
+        ? getFirstFullPeriodOnOrAfter({
+              date: minCalendarDate,
+              periodType,
+              calendar,
+              locale,
+          })
+        : null
+    const maxPeriod = maxCalendarDate
+        ? getLastFullPeriodOnOrBefore({
+              date: maxCalendarDate,
+              periodType,
+              calendar,
+              locale,
+          })
+        : null
+
+    const hasCompleteFixedPeriods = Boolean(
+        (!minCalendarDate || minPeriod) &&
+            (!maxCalendarDate || maxPeriod) &&
+            (!minPeriod ||
+                !maxPeriod ||
+                compareFixedPeriods(minPeriod, maxPeriod) <= 0)
+    )
+
+    return {
+        hasCompleteFixedPeriods,
+        maxCalendarDate,
+        maxPeriod,
+        maxPeriodId: maxPeriod?.id,
+        maxStandardDate,
+        minCalendarDate,
+        minPeriod,
+        minPeriodId: minPeriod?.id,
+        minStandardDate,
+    }
+}
+
+const clampFixedPeriod = ({ period, minPeriod, maxPeriod }) => {
+    if (minPeriod && compareFixedPeriods(period, minPeriod) < 0) {
+        return minPeriod
+    }
+
+    if (maxPeriod && compareFixedPeriods(period, maxPeriod) > 0) {
+        return maxPeriod
+    }
+
+    return period
+}
+
+export const getSnappedFixedPeriodRange = ({
+    startTime,
+    endTime,
+    periodType,
+    calendar,
+    locale,
+    minPeriod,
+    maxPeriod,
+}) => {
+    const startPeriod = getFixedPeriodForDate({
+        date: startTime,
+        periodType,
+        calendar,
+        locale,
+    })
+    const endPeriod = getFixedPeriodForDate({
+        date: endTime,
+        periodType,
+        calendar,
+        locale,
+    })
+
+    if (!startPeriod || !endPeriod) {
+        return null
+    }
+
+    const snappedStartPeriod = clampFixedPeriod({
+        period: startPeriod,
+        minPeriod,
+        maxPeriod,
+    })
+    let snappedEndPeriod = clampFixedPeriod({
+        period: endPeriod,
+        minPeriod,
+        maxPeriod,
+    })
+
+    if (compareFixedPeriods(snappedStartPeriod, snappedEndPeriod) > 0) {
+        snappedEndPeriod = snappedStartPeriod
+    }
+
+    return {
+        startTime: snappedStartPeriod.startDate,
+        endTime: snappedEndPeriod.endDate,
+    }
+}

--- a/src/utils/periodEngine.js
+++ b/src/utils/periodEngine.js
@@ -1,0 +1,153 @@
+import {
+    getAdjacentFixedPeriods as getAdjacentFixedPeriodsFromLibrary,
+    createFixedPeriodFromPeriodId as createFixedPeriodFromPeriodIdFromLibrary,
+    generateFixedPeriods as generateFixedPeriodsFromLibrary,
+    getFixedPeriodByDate as getFixedPeriodByDateFromLibrary,
+    getNowInCalendar,
+} from '@dhis2/multi-calendar-dates'
+
+export const DEFAULT_DHIS2_CALENDAR = 'gregory'
+export const DEFAULT_DHIS2_LOCALE = 'en'
+export const DEFAULT_DHIS2_TIME_ZONE = 'Etc/UTC'
+
+export const WEEKLY = 'WEEKLY'
+export const MONTHLY = 'MONTHLY'
+
+const DHIS2_CALENDAR_MAP = {
+    buddhist: 'buddhist',
+    coptic: 'coptic',
+    ethiopian: 'ethiopic',
+    ethiopic: 'ethiopic',
+    gregorian: 'gregory',
+    gregory: 'gregory',
+    islamic: 'islamic',
+    iso8601: 'iso8601',
+    nepali: 'nepali',
+    persian: 'persian',
+    thai: 'buddhist',
+}
+
+const stripLeadingZeroes = (value) => value.replace(/^0+(?=\d)/, '')
+
+const padWithZeroes = (value) => String(value).padStart(2, '0')
+
+export const normalizeDhis2Calendar = (calendar = DEFAULT_DHIS2_CALENDAR) => {
+    if (!calendar) {
+        return DEFAULT_DHIS2_CALENDAR
+    }
+
+    const normalizedCalendar = String(calendar).toLowerCase()
+    return DHIS2_CALENDAR_MAP[normalizedCalendar] || calendar
+}
+
+export const canonicalizePeriodId = (periodId) => {
+    const trimmedPeriodId = String(periodId ?? '').trim()
+    const weeklyMatch = trimmedPeriodId.match(
+        /^(\d{4})([A-Z][a-z]{2})?W0*(\d+)$/
+    )
+
+    if (weeklyMatch) {
+        const [, year, offset = '', week] = weeklyMatch
+        return `${year}${offset}W${stripLeadingZeroes(week)}`
+    }
+
+    const biWeeklyMatch = trimmedPeriodId.match(/^(\d{4})BiW0*(\d+)$/)
+
+    if (biWeeklyMatch) {
+        const [, year, week] = biWeeklyMatch
+        return `${year}BiW${stripLeadingZeroes(week)}`
+    }
+
+    return trimmedPeriodId
+}
+
+export const isSupportedFixedPeriodType = (periodType) =>
+    periodType === WEEKLY || periodType === MONTHLY
+
+const assertSupportedFixedPeriodType = (periodType) => {
+    if (!isSupportedFixedPeriodType(periodType)) {
+        throw new Error(`Unsupported DHIS2 period type "${periodType}"`)
+    }
+}
+
+export const generateFixedPeriods = ({
+    year,
+    periodType,
+    calendar,
+    locale = DEFAULT_DHIS2_LOCALE,
+}) => {
+    assertSupportedFixedPeriodType(periodType)
+
+    return generateFixedPeriodsFromLibrary({
+        year,
+        periodType,
+        calendar: normalizeDhis2Calendar(calendar),
+        locale,
+    })
+}
+
+export const createFixedPeriodFromPeriodId = ({
+    periodId,
+    calendar,
+    locale = DEFAULT_DHIS2_LOCALE,
+}) =>
+    createFixedPeriodFromPeriodIdFromLibrary({
+        periodId: canonicalizePeriodId(periodId),
+        calendar: normalizeDhis2Calendar(calendar),
+        locale,
+    })
+
+export const getFixedPeriodByDate = ({
+    periodType,
+    date,
+    calendar,
+    locale = DEFAULT_DHIS2_LOCALE,
+}) => {
+    assertSupportedFixedPeriodType(periodType)
+
+    return getFixedPeriodByDateFromLibrary({
+        periodType,
+        date,
+        calendar: normalizeDhis2Calendar(calendar),
+        locale,
+    })
+}
+
+export const getAdjacentFixedPeriod = ({
+    period,
+    steps,
+    calendar,
+    locale = DEFAULT_DHIS2_LOCALE,
+}) =>
+    getAdjacentFixedPeriodsFromLibrary({
+        period,
+        steps,
+        calendar: normalizeDhis2Calendar(calendar),
+        locale,
+    })[0]
+
+export const getTodayInCalendar = ({
+    calendar,
+    timeZone = DEFAULT_DHIS2_TIME_ZONE,
+}) => {
+    const now = getNowInCalendar(normalizeDhis2Calendar(calendar), timeZone)
+    const year = now.eraYear ?? now.year
+
+    return `${year}-${padWithZeroes(now.month)}-${padWithZeroes(now.day)}`
+}
+
+export const compareFixedPeriods = (a, b) => {
+    const startDateComparison = a.startDate.localeCompare(b.startDate)
+
+    if (startDateComparison !== 0) {
+        return startDateComparison
+    }
+
+    const endDateComparison = a.endDate.localeCompare(b.endDate)
+
+    if (endDateComparison !== 0) {
+        return endDateComparison
+    }
+
+    return a.id.localeCompare(b.id)
+}

--- a/src/utils/periodEngine.js
+++ b/src/utils/periodEngine.js
@@ -31,6 +31,29 @@ const stripLeadingZeroes = (value) => value.replace(/^0+(?=\d)/, '')
 
 const padWithZeroes = (value) => String(value).padStart(2, '0')
 
+const isDigitSequence = (value) => {
+    if (!value) {
+        return false
+    }
+
+    for (const char of value) {
+        if (char < '0' || char > '9') {
+            return false
+        }
+    }
+
+    return true
+}
+
+const isWeeklyOffset = (value) =>
+    value.length === 3 &&
+    value[0] >= 'A' &&
+    value[0] <= 'Z' &&
+    value[1] >= 'a' &&
+    value[1] <= 'z' &&
+    value[2] >= 'a' &&
+    value[2] <= 'z'
+
 export const normalizeDhis2Calendar = (calendar = DEFAULT_DHIS2_CALENDAR) => {
     if (!calendar) {
         return DEFAULT_DHIS2_CALENDAR
@@ -42,20 +65,31 @@ export const normalizeDhis2Calendar = (calendar = DEFAULT_DHIS2_CALENDAR) => {
 
 export const canonicalizePeriodId = (periodId) => {
     const trimmedPeriodId = String(periodId ?? '').trim()
-    const weeklyMatch = trimmedPeriodId.match(
-        /^(\d{4})([A-Z][a-z]{2})?W0*(\d+)$/
-    )
+    const year = trimmedPeriodId.slice(0, 4)
 
-    if (weeklyMatch) {
-        const [, year, offset = '', week] = weeklyMatch
-        return `${year}${offset}W${stripLeadingZeroes(week)}`
+    if (!isDigitSequence(year)) {
+        return trimmedPeriodId
     }
 
-    const biWeeklyMatch = trimmedPeriodId.match(/^(\d{4})BiW0*(\d+)$/)
+    const rest = trimmedPeriodId.slice(4)
+    const biWeeklyPrefix = 'BiW'
 
-    if (biWeeklyMatch) {
-        const [, year, week] = biWeeklyMatch
+    if (rest.startsWith(biWeeklyPrefix)) {
+        const week = rest.slice(biWeeklyPrefix.length)
+        if (!isDigitSequence(week)) {
+            return trimmedPeriodId
+        }
         return `${year}BiW${stripLeadingZeroes(week)}`
+    }
+
+    const weekMarkerIndex = rest.indexOf('W')
+    if (weekMarkerIndex !== -1) {
+        const offset = rest.slice(0, weekMarkerIndex)
+        const week = rest.slice(weekMarkerIndex + 1)
+
+        if (isDigitSequence(week) && (!offset || isWeeklyOffset(offset))) {
+            return `${year}${offset}W${stripLeadingZeroes(week)}`
+        }
     }
 
     return trimmedPeriodId


### PR DESCRIPTION
- Added fixed weekly and monthly period range selectors to import and saved import flows.
- Reused multi-calendar date utilities for DHIS2 calendar normalization and period boundaries.
- Updated focused tests and Cypress selector helpers for the new period controls.
